### PR TITLE
Add incrementalUpdateSkipDelete option to ElementApi.createElements()

### DIFF
--- a/source/api/element_api.ts
+++ b/source/api/element_api.ts
@@ -59,8 +59,12 @@ export default class ElementApi {
 
   static createElements({ projectId, floorId }: AssociationIds,
                         elements: DetailedElement<any>[],
+                        incrementalUpdateSkipDelete: boolean,
                         user: User): Promise<void> {
     let url = `${Http.baseUrl()}/projects/${projectId}/floors/${floorId}/planned-building-elements`;
+    if (incrementalUpdateSkipDelete) {
+      url += "?incrementalUpdateSkipDelete=true";
+    }
     return Http.post(url, user, elements);
   }
 


### PR DESCRIPTION
To reflect a change in the API which allows uploading elements in
multiple chunks.

When uploading chunks of PBEs to a floor, set
incrementalUpdateSkipDelete to false on the first call. Then set to true
on subsequent calls for the same floor.