### PR TITLE
Retain floor files based on user selection [BSI-288]

### DIFF
--- a/source/api/floor_api.ts
+++ b/source/api/floor_api.ts
@@ -7,6 +7,7 @@ import { User } from "../utilities/get_authorization_headers";
 import {ApiPlannedElement} from "../models";
 import {DateConverter} from "../converters";
 import {DateLike} from "type_aliases";
+import FloorFileDeletionModeConverter from "../converters/floor_file_deletion_mode_converter";
 
 export default class FloorApi {
   static listFloorsForProject(projectId: string, user: User): Promise<ApiFloor[]> {
@@ -35,7 +36,13 @@ export default class FloorApi {
   }
 
   static deleteFloor({ projectId, floorId, deletionModeSelection }, user: User): Promise<void> {
-    const url = `${Http.baseUrl()}/projects/${projectId}/floors/${floorId}/mode/${deletionModeSelection}`;
+    let query: any;
+    if (deletionModeSelection && typeof deletionModeSelection === "string" && deletionModeSelection != "") {
+      query = `?deletionModeSelection=${FloorFileDeletionModeConverter.toApiFloorFileDeletionMode(deletionModeSelection)}`;
+    } else {
+      query = "";
+    }
+    const url = `${Http.baseUrl()}/projects/${projectId}/floors/${floorId}${query}`;
     return Http.delete(url, user);
   }
 

--- a/source/api/floor_api.ts
+++ b/source/api/floor_api.ts
@@ -34,8 +34,8 @@ export default class FloorApi {
     return Http.post(url, user, floorIds);
   }
 
-  static deleteFloor({ projectId, floorId }, user: User): Promise<void> {
-    const url = `${Http.baseUrl()}/projects/${projectId}/floors/${floorId}`;
+  static deleteFloor({ projectId, floorId, deletionModeSelection }, user: User): Promise<void> {
+    const url = `${Http.baseUrl()}/projects/${projectId}/floors/${floorId}/mode/${deletionModeSelection}`;
     return Http.delete(url, user);
   }
 

--- a/source/converters/floor_file_deletion_mode_converter.ts
+++ b/source/converters/floor_file_deletion_mode_converter.ts
@@ -1,0 +1,20 @@
+import _ from "underscore";
+import {ApiFloorFileDeletionMode} from "../models/api/ApiFloorFileDeletionMode";
+
+const apiFloorFileDeletionModes = _.invert(ApiFloorFileDeletionMode);
+
+type ApiFloorFileDeletionModeKeys = keyof typeof ApiFloorFileDeletionMode;
+const apiFloorFileDeletionModeTypeKeys: ApiFloorFileDeletionModeKeys[] = Object.values(ApiFloorFileDeletionMode);
+
+const isApiFloorFileDeletionMode = (type: any): type is ApiFloorFileDeletionMode => apiFloorFileDeletionModeTypeKeys.includes(type);
+
+export class FloorFileDeletionModeConverter {
+    static toApiFloorFileDeletionMode(fileKey: ApiFloorFileDeletionMode): ApiFloorFileDeletionMode {
+        if (isApiFloorFileDeletionMode(fileKey)) {
+            return fileKey;
+        }
+        return apiFloorFileDeletionModes[fileKey];
+    }
+}
+
+export default FloorFileDeletionModeConverter;

--- a/source/models/api/ApiFloorFileDeletionMode.ts
+++ b/source/models/api/ApiFloorFileDeletionMode.ts
@@ -1,0 +1,4 @@
+export enum ApiFloorFileDeletionMode {
+    ALL_FILES = "ALL_FILES",
+    FLOOR_ONLY = "FLOOR_ONLY"
+}

--- a/tests/api/floor_api_test.ts
+++ b/tests/api/floor_api_test.ts
@@ -10,6 +10,7 @@ import Http from "../../source/utilities/http";
 import {FIREBASE} from "../../source/models/enums/user_auth_type";
 import {User} from "../../source/utilities/get_authorization_headers";
 import {ApiMasterformat, ApiMasterformatProgress, ApiPlannedElement, ProgressType} from "../../source";
+import {ApiFloorFileDeletionMode} from "../../source/models/api/ApiFloorFileDeletionMode";
 
 describe("FloorApi", () => {
     let user;
@@ -219,7 +220,7 @@ describe("FloorApi", () => {
 
     describe("#deleteFloor", () => {
         beforeEach(() => {
-            fetchMock.delete(`${Http.baseUrl()}/projects/some-project-id/floors/some-floor-id/mode/`, 200);
+            fetchMock.delete(`${Http.baseUrl()}/projects/some-project-id/floors/some-floor-id`, 200);
         });
 
         it("makes a call to the correct endpoint", () => {
@@ -233,7 +234,7 @@ describe("FloorApi", () => {
 
             expect(lastFetchOpts.headers).to.include.keys("Content-Type");
             expect(lastFetchOpts.headers["Content-Type"]).to.eq("application/json");
-            expect(fetchCall[0]).to.eq(`${Http.baseUrl()}/projects/some-project-id/floors/some-floor-id/mode/`);
+            expect(fetchCall[0]).to.eq(`${Http.baseUrl()}/projects/some-project-id/floors/some-floor-id`);
         });
 
         it("sends the request with authorization headers", () => {
@@ -245,14 +246,14 @@ describe("FloorApi", () => {
             const fetchCall = fetchMock.lastCall();
             const lastFetchOpts = fetchMock.lastOptions();
 
-            expect(fetchCall[0]).to.eq(`${Http.baseUrl()}/projects/some-project-id/floors/some-floor-id/mode/`);
+            expect(fetchCall[0]).to.eq(`${Http.baseUrl()}/projects/some-project-id/floors/some-floor-id`);
             expect(lastFetchOpts.headers).to.include.key("firebaseIdToken");
             expect(lastFetchOpts.headers.firebaseIdToken).to.eq("some-firebase.id.token");
         });
 
         describe("when the call fails", () => {
             beforeEach(() => {
-                fetchMock.delete(`${Http.baseUrl()}/projects/some-project-id/floors/some-floor-id/mode/`,
+                fetchMock.delete(`${Http.baseUrl()}/projects/some-project-id/floors/some-floor-id`,
                     {
                         status: 500, body: {some: "body"},
                         headers: {"ContentType": "application/json"}
@@ -272,6 +273,27 @@ describe("FloorApi", () => {
                     .finally(() => {
                         expect(Config.sharedErrorHandler).to.have.been.calledWithMatch({});
                     });
+            });
+        });
+
+        describe("delete floors with deletion mode selection", () => {
+            beforeEach(() => {
+                fetchMock.delete(`${Http.baseUrl()}/projects/some-project-id/floors/some-floor-id?deletionModeSelection=${ApiFloorFileDeletionMode.ALL_FILES}`, 200);
+            });
+
+            it("delete floor with deletion mode ALL_FILES", () => {
+                return FloorApi.deleteFloor({
+                        projectId: "some-project-id",
+                        floorId: "some-floor-id",
+                        deletionModeSelection: "ALL_FILES"
+                    }, user);
+
+                const fetchCall = fetchMock.lastCall();
+                const lastFetchOpts = fetchMock.lastOptions();
+
+                expect(fetchCall[0]).to.eq(`${Http.baseUrl()}/projects/some-project-id/floors/some-floor-id?deletionModeSelection=${ApiFloorFileDeletionMode.ALL_FILES}`);
+                expect(lastFetchOpts.headers).to.include.key("firebaseIdToken");
+                expect(lastFetchOpts.headers.firebaseIdToken).to.eq("some-firebase.id.token");
             });
         });
     });

--- a/tests/api/floor_api_test.ts
+++ b/tests/api/floor_api_test.ts
@@ -219,7 +219,7 @@ describe("FloorApi", () => {
 
     describe("#deleteFloor", () => {
         beforeEach(() => {
-            fetchMock.delete(`${Http.baseUrl()}/projects/some-project-id/floors/some-floor-id`, 200);
+            fetchMock.delete(`${Http.baseUrl()}/projects/some-project-id/floors/some-floor-id/mode/`, 200);
         });
 
         it("makes a call to the correct endpoint", () => {
@@ -233,7 +233,7 @@ describe("FloorApi", () => {
 
             expect(lastFetchOpts.headers).to.include.keys("Content-Type");
             expect(lastFetchOpts.headers["Content-Type"]).to.eq("application/json");
-            expect(fetchCall[0]).to.eq(`${Http.baseUrl()}/projects/some-project-id/floors/some-floor-id`);
+            expect(fetchCall[0]).to.eq(`${Http.baseUrl()}/projects/some-project-id/floors/some-floor-id/mode/`);
         });
 
         it("sends the request with authorization headers", () => {
@@ -245,7 +245,7 @@ describe("FloorApi", () => {
             const fetchCall = fetchMock.lastCall();
             const lastFetchOpts = fetchMock.lastOptions();
 
-            expect(fetchCall[0]).to.eq(`${Http.baseUrl()}/projects/some-project-id/floors/some-floor-id`);
+            expect(fetchCall[0]).to.eq(`${Http.baseUrl()}/projects/some-project-id/floors/some-floor-id/mode/`);
             expect(lastFetchOpts.headers).to.include.key("firebaseIdToken");
             expect(lastFetchOpts.headers.firebaseIdToken).to.eq("some-firebase.id.token");
         });

--- a/tests/api/floor_api_test.ts
+++ b/tests/api/floor_api_test.ts
@@ -225,7 +225,8 @@ describe("FloorApi", () => {
         it("makes a call to the correct endpoint", () => {
             FloorApi.deleteFloor({
                 projectId: "some-project-id",
-                floorId: "some-floor-id"
+                floorId: "some-floor-id",
+                deletionModeSelection: ""
             }, {firebaseUser: {idToken: "some-firebase.id.token"}} as User);
             const fetchCall = fetchMock.lastCall();
             const lastFetchOpts = fetchMock.lastOptions();
@@ -238,7 +239,8 @@ describe("FloorApi", () => {
         it("sends the request with authorization headers", () => {
             FloorApi.deleteFloor({
                 projectId: "some-project-id",
-                floorId: "some-floor-id"
+                floorId: "some-floor-id",
+                deletionModeSelection: ""
             }, user);
             const fetchCall = fetchMock.lastCall();
             const lastFetchOpts = fetchMock.lastOptions();
@@ -262,7 +264,8 @@ describe("FloorApi", () => {
                 sandbox.stub(Config, "sharedErrorHandler");
                 return FloorApi.deleteFloor({
                         projectId: "some-project-id",
-                        floorId: "some-floor-id"
+                        floorId: "some-floor-id",
+                        deletionModeSelection: ""
                     },
                     {firebaseUser: {idToken: "some-firebase.id.token"}} as User)
                     .catch(_.noop)

--- a/tests/api/floor_api_test.ts
+++ b/tests/api/floor_api_test.ts
@@ -252,7 +252,7 @@ describe("FloorApi", () => {
 
         describe("when the call fails", () => {
             beforeEach(() => {
-                fetchMock.delete(`${Http.baseUrl()}/projects/some-project-id/floors/some-floor-id`,
+                fetchMock.delete(`${Http.baseUrl()}/projects/some-project-id/floors/some-floor-id/mode/`,
                     {
                         status: 500, body: {some: "body"},
                         headers: {"ContentType": "application/json"}


### PR DESCRIPTION
- Updated the `deleteFloor` api endpoint that deletes the floor to now carry an additional argument that specifies the mode of deletion of floor selected by the user 