### PR TITLE
Refactor: Make imports and exports more consistent and auto-format

### DIFF
--- a/source/api/index.ts
+++ b/source/api/index.ts
@@ -17,6 +17,7 @@ import TradeApi from "./trade_api";
 import UserApi from "./user_api";
 import WebGatewayApi from "./web_gateway_api";
 import WebRpcApi from "./web_rpc_api";
+import WorkPackageApi from "./work_package_api";
 
 export {
   AuthApi,
@@ -38,4 +39,5 @@ export {
   UserApi,
   WebGatewayApi,
   WebRpcApi,
+  WorkPackageApi
 };

--- a/source/api/photo_area_api.ts
+++ b/source/api/photo_area_api.ts
@@ -1,22 +1,23 @@
-import {isArray} from "underscore";
-import {ApiPhotoArea, ApiPhotoLocation, ApiPhotoSession, ApiPhotoLocation3d, AssociationIds} from "../models";
-import {User} from "../utilities/get_authorization_headers";
+import { isArray } from "underscore";
+import { ApiPhotoArea, ApiPhotoLocation, ApiPhotoLocation3d, ApiPhotoSession, AssociationIds } from "../models";
+import { User } from "../utilities/get_authorization_headers";
 import makeErrorsPretty from "../utilities/make_errors_pretty";
 import Http from "../utilities/http";
 
 export default class PhotoAreaApi {
 
-  static createPhotoLocations({ projectId, photoAreaId, photoSessionId}: AssociationIds,
+  static createPhotoLocations({ projectId, photoAreaId, photoSessionId }: AssociationIds,
                               locations: ApiPhotoLocation[],
                               user: User): Promise<ApiPhotoLocation[]> {
     let url = `${Http.baseUrl()}/projects/${projectId}/photo-areas/${photoAreaId}/locations`;
     if (photoSessionId) {
-      url += `?photoSessionId=${photoSessionId}`
+      url += `?photoSessionId=${photoSessionId}`;
     }
     return Http.post(url, user, locations) as unknown as Promise<ApiPhotoLocation[]>;
   }
 
-  static listPhotoAreasForProject({ projectId, integrationProjectId }: AssociationIds, user: User): Promise<ApiPhotoArea[]> {
+  static listPhotoAreasForProject({ projectId, integrationProjectId }: AssociationIds,
+                                  user: User): Promise<ApiPhotoArea[]> {
     let url = `${Http.baseUrl()}/projects/${projectId}/photo-areas`;
     if (integrationProjectId != null) {
       url += `?integrationProjectId=${integrationProjectId}`;
@@ -24,7 +25,8 @@ export default class PhotoAreaApi {
     return Http.get(url, user) as unknown as Promise<ApiPhotoArea[]>;
   }
 
-  static listPhotoLocations({ projectId, photoAreaId, photoSessionId }: AssociationIds, user: User): Promise<ApiPhotoLocation[]> {
+  static listPhotoLocations({ projectId, photoAreaId, photoSessionId }: AssociationIds,
+                            user: User): Promise<ApiPhotoLocation[]> {
     let url = `${Http.baseUrl()}/projects/${projectId}/photo-areas/${photoAreaId}/locations`;
     if (photoSessionId) {
       if (isArray(photoSessionId)) {
@@ -36,7 +38,8 @@ export default class PhotoAreaApi {
     return Http.get(url, user) as unknown as Promise<ApiPhotoLocation[]>;
   }
 
-  static listPhotoSessionsForPhotoArea({ projectId, photoAreaId }: AssociationIds, user: User): Promise<ApiPhotoSession[]> {
+  static listPhotoSessionsForPhotoArea({ projectId, photoAreaId }: AssociationIds,
+                                       user: User): Promise<ApiPhotoSession[]> {
     let url = `${Http.baseUrl()}/projects/${projectId}/photo-areas/${photoAreaId}/sessions`;
     return Http.get(url, user) as unknown as Promise<ApiPhotoSession[]>;
   }

--- a/source/api/project_api.ts
+++ b/source/api/project_api.ts
@@ -1,12 +1,10 @@
 import getAuthorizationHeaders, { User } from "../utilities/get_authorization_headers";
 import Http from "../utilities/http";
 import makeErrorsPretty from "../utilities/make_errors_pretty";
-
-import { ApiCloudFile, ApiMasterformatProgress, ApiProject, ApiProjectCostAnalysisProgress, ApiProjectCostAnalysisProgressValidationResult, ApiProjectListing, ApiProjectWorkPackage, ApiRunningProcess, AssociationIds, ProgressType, ProjectWorkPackageType } from "../models";
-import { DateLike } from "type_aliases";
 import { DateConverter } from "../converters";
-import { ApiClassificationCode } from "../models/api/api_classification_code";
-import ApiProjectWorkPackageCost from "../models/api/api_project_work_package_cost";
+
+import type { ApiClassificationCode, ApiCloudFile, ApiMasterformatProgress, ApiProject, ApiProjectCostAnalysisProgress, ApiProjectCostAnalysisProgressValidationResult, ApiProjectListing, ApiProjectWorkPackage, ApiProjectWorkPackageCost, ApiRunningProcess, AssociationIds, ProgressType, ProjectWorkPackageType } from "../models";
+import type { DateLike } from "type_aliases";
 
 export default class ProjectApi {
   static listProjectsForOrganization(organizationId: string, user: User): Promise<ApiProject[]> {

--- a/source/api/scan_dataset_api.ts
+++ b/source/api/scan_dataset_api.ts
@@ -1,4 +1,4 @@
-import ApiView, { ViewParameter } from "../models/api/api_view";
+import ApiView, { ApiViewArgument } from "../models/api/api_view";
 import Http from "../utilities/http";
 import makeErrorsPretty from "../utilities/make_errors_pretty";
 import { ApiBuiltStatus, ApiDetailedElement, ApiPhotoSession, ApiScanDataset, ApiScanDatasetQaState, ApiScannedElementType, AssociationIds, DateLike } from "../models";
@@ -124,9 +124,9 @@ export default class ScanDatasetApi {
                                   projectId,
                                   floorId,
                                   scanDatasetId
-                                }: AssociationIds, user: User): Promise<ViewParameter[]> {
+                                }: AssociationIds, user: User): Promise<ApiViewArgument[]> {
     const url = `${Http.baseUrl()}/projects/${projectId}/floors/${floorId}/scan-datasets/${scanDatasetId}/views`;
-    return Http.get(url, user) as unknown as Promise<ViewParameter[]>;
+    return Http.get(url, user) as unknown as Promise<ApiViewArgument[]>;
   }
 
   static getNewElementsForScanDataset({ projectId, floorId, scanDatasetId }: AssociationIds,

--- a/source/avvir_api.ts
+++ b/source/avvir_api.ts
@@ -19,7 +19,8 @@ export default {
   reports: Api.ReportApi,
   scanDatasets: Api.ScanDatasetApi,
   trades: Api.TradeApi,
-  other: Api.WebGatewayApi,
-  webRpcApi: Api.WebRpcApi,
   user: Api.UserApi,
+  webRpcApi: Api.WebRpcApi,
+  workPackages: Api.WorkPackageApi,
+  other: Api.WebGatewayApi,
 };

--- a/source/converters/floor_file_deletion_mode_converter.ts
+++ b/source/converters/floor_file_deletion_mode_converter.ts
@@ -1,20 +1,22 @@
 import _ from "underscore";
-import {ApiFloorFileDeletionMode} from "../models/api/ApiFloorFileDeletionMode";
+
+import ApiFloorFileDeletionMode from "../models/enums/api_floor_file_deletion_mode";
 
 const apiFloorFileDeletionModes = _.invert(ApiFloorFileDeletionMode);
 
 type ApiFloorFileDeletionModeKeys = keyof typeof ApiFloorFileDeletionMode;
 const apiFloorFileDeletionModeTypeKeys: ApiFloorFileDeletionModeKeys[] = Object.values(ApiFloorFileDeletionMode);
 
-const isApiFloorFileDeletionMode = (type: any): type is ApiFloorFileDeletionMode => apiFloorFileDeletionModeTypeKeys.includes(type);
+const isApiFloorFileDeletionMode = (type: any): type is ApiFloorFileDeletionMode => apiFloorFileDeletionModeTypeKeys.includes(
+  type);
 
 export class FloorFileDeletionModeConverter {
-    static toApiFloorFileDeletionMode(fileKey: ApiFloorFileDeletionMode): ApiFloorFileDeletionMode {
-        if (isApiFloorFileDeletionMode(fileKey)) {
-            return fileKey;
-        }
-        return apiFloorFileDeletionModes[fileKey];
+  static toApiFloorFileDeletionMode(fileKey: ApiFloorFileDeletionMode): ApiFloorFileDeletionMode {
+    if (isApiFloorFileDeletionMode(fileKey)) {
+      return fileKey;
     }
+    return apiFloorFileDeletionModes[fileKey];
+  }
 }
 
 export default FloorFileDeletionModeConverter;

--- a/source/models/api/ApiFloorFileDeletionMode.ts
+++ b/source/models/api/ApiFloorFileDeletionMode.ts
@@ -1,4 +1,0 @@
-export enum ApiFloorFileDeletionMode {
-    ALL_FILES = "ALL_FILES",
-    FLOOR_ONLY = "FLOOR_ONLY"
-}

--- a/source/models/api/api_action_payload.ts
+++ b/source/models/api/api_action_payload.ts
@@ -1,4 +1,4 @@
-import {Vector3Like} from "./type_aliases";
+import type { Vector3Like } from "./type_aliases";
 
 export type ApiBehavioralData = {
   deviation?: Vector3Like
@@ -15,7 +15,8 @@ export class ApiActionPayload {
               photoSessionId: number,
               photoLocationId: number,
               scannedBuildingElementId: number,
-              behavioralData: ApiBehavioralData) {
+              behavioralData: ApiBehavioralData)
+  {
     this.globalId = globalId;
     this.firebaseClientAccountId = firebaseClientAccountId;
     this.firebaseProjectId = firebaseProjectId;
@@ -38,5 +39,6 @@ export class ApiActionPayload {
   photoLocationId?: number;
   scannedBuildingElementId?: number;
   behavioralData?: ApiBehavioralData;
-
 }
+
+export default ApiActionPayload;

--- a/source/models/api/api_argo_response.ts
+++ b/source/models/api/api_argo_response.ts
@@ -10,7 +10,17 @@ export type ArgoMetadata = {
 }
 
 export class ApiArgoResponse {
-  constructor({ name, generateName, namespace, selfLink, uid, resourceVersion, generation, creationTimestamp }: Partial<ArgoMetadata> = {}) {
+  constructor({
+                name,
+                generateName,
+                namespace,
+                selfLink,
+                uid,
+                resourceVersion,
+                generation,
+                creationTimestamp
+              }: Partial<ArgoMetadata> = {})
+  {
     this.metadata = {
       name,
       generateName,

--- a/source/models/api/api_bcf_building_element.ts
+++ b/source/models/api/api_bcf_building_element.ts
@@ -1,10 +1,10 @@
-import {ApiDetailedElement} from "./api_detailed_element";
-import {ApiBcfIssue} from "./api_bcf_issue";
+import type { ApiBcfIssue } from "./api_bcf_issue";
+import type { ApiDetailedElement } from "./api_detailed_element";
 
-export type ApiBcfBuildingElementArgs = Partial<ApiBcfBuildingElement>;
+export type ApiBcfBuildingElementArgument = Partial<ApiBcfBuildingElement>;
 
 export class ApiBcfBuildingElement {
-  constructor({bcfIssue, detailedElement}: ApiBcfBuildingElementArgs = {}) {
+  constructor({ bcfIssue, detailedElement }: ApiBcfBuildingElementArgument = {}) {
     this.detailedElement = detailedElement;
     this.bcfIssue = bcfIssue;
   }

--- a/source/models/api/api_bcf_issue.ts
+++ b/source/models/api/api_bcf_issue.ts
@@ -1,7 +1,7 @@
-export type ApiBcfIssueArgs = Partial<ApiBcfIssue>;
+export type ApiBcfIssueArgument = Partial<ApiBcfIssue>;
 
 export class ApiBcfIssue {
-  constructor({plannedBuildingElementId, commentGuid, viewpointGuid, topicGuid}: ApiBcfIssueArgs = {}) {
+  constructor({plannedBuildingElementId, commentGuid, viewpointGuid, topicGuid}: ApiBcfIssueArgument = {}) {
     this.plannedBuildingElementId = plannedBuildingElementId;
     this.commentGuid = commentGuid;
     this.topicGuid = topicGuid;

--- a/source/models/api/api_cloud_file.ts
+++ b/source/models/api/api_cloud_file.ts
@@ -1,25 +1,23 @@
-import { DateLike, Modify } from "./type_aliases";
 import { addInstantGetterAndSetterToApiModel, addReadOnlyPropertiesToModel } from "../../mixins";
 import { ApiProjectPurposeType, ApiPurposeType, isApiPurposeType } from "./api_purpose_type";
-import { PurposeTypeConverter } from "../../converters";
 import { AssociationType, isPurposeType, PurposeType } from "../enums";
-import ApiPhotoLocation3d from "./api_photo_location_3d";
+import { PurposeTypeConverter } from "../../converters";
+
+import type ApiPhotoLocation3d from "./api_photo_location_3d";
+import type { DateLike, ModifyPartial, Vector2Like } from "type_aliases";
 
 export type AvvirApiFiles<Type extends ApiPurposeType = ApiPurposeType> = { [purposeType in Type]?: ApiCloudFile | ApiCloudFile[] }
 export type AvvirApiFileIds<Type extends ApiPurposeType = ApiPurposeType> = { [purposeType in Type]?: number[] }
 
 export interface ApiCloudFileMetadata {
-  offset?: { x: number, y: number };
+  offset?: Vector2Like;
 }
 
-export interface ApiCloudFileArgument extends Partial<Modify<ApiCloudFile, {
+export type ApiCloudFileArgument = ModifyPartial<ApiCloudFile, {
   lastModified?: DateLike
   createdAt?: DateLike
   purposeType: ApiPurposeType | PurposeType,
-  fileType?: string
-}>>
-{
-}
+}>
 
 export class ApiCloudFile {
   constructor({

--- a/source/models/api/api_cloud_file_location_3d.ts
+++ b/source/models/api/api_cloud_file_location_3d.ts
@@ -11,7 +11,7 @@ export type ApiCloudFileLocationId = {
   orientation: ApiQuaternion
 }
 
-export type ApiCloudFileLocation3dArguments = {
+export type ApiCloudFileLocation3dArgument = {
   id: number,
   position: Vector3Like,
   orientation: Vector4Like
@@ -25,7 +25,7 @@ export class ApiCloudFileLocation3d {
         id,
         position,
         orientation
-      }: ApiCloudFileLocation3dArguments ) {
+      }: ApiCloudFileLocation3dArgument ) {
     addReadOnlyPropertiesToModel(this, { id });
     this.position = position;
     this.orientation = ApiQuaternion.create(orientation);

--- a/source/models/api/api_construction_grid.ts
+++ b/source/models/api/api_construction_grid.ts
@@ -1,5 +1,6 @@
-import {addReadOnlyPropertiesToModel} from "../../mixins";
-import ApiGridLine from "./api_grid_line";
+import { addReadOnlyPropertiesToModel } from "../../mixins";
+
+import type ApiGridLine from "./api_grid_line";
 
 export class ApiConstructionGrid {
   constructor({ id, globalId, axisULines, axisVLines, firebaseFloorId }: Partial<ApiConstructionGrid>) {
@@ -10,8 +11,8 @@ export class ApiConstructionGrid {
 
   readonly id: number | null = null;
   readonly globalId: string | null = null;
-  axisULines: Array<ApiGridLine> = [];
-  axisVLines: Array<ApiGridLine> = [];
+  axisULines: ApiGridLine[] = [];
+  axisVLines: ApiGridLine[] = [];
   readonly firebaseFloorId: string | null = null;
 }
 

--- a/source/models/api/api_detailed_element.ts
+++ b/source/models/api/api_detailed_element.ts
@@ -1,27 +1,29 @@
-import {ApiPlannedElement} from "./api_planned_element";
-import {ApiBuiltStatus} from "../enums";
-import {ApiElementDeviation} from "./api_element_deviation";
-import {ApiScannedElementTypeMap, isDeviationScanResult} from "./api_scanned_element";
-import {addInstantGetterAndSetterToApiModel} from "../../mixins";
+import ApiElementDeviation from "./api_element_deviation";
+import ApiPlannedElement from "./api_planned_element";
+import { addInstantGetterAndSetterToApiModel } from "../../mixins";
+import { ApiScannedElementTypeMap, isDeviationScanResult } from "./api_scanned_element";
 
+import type { ApiBuiltStatus } from "../enums";
+
+/** @deprecated This information should now all live in the {@link ApiPlannedElement}. */
 export class ApiDetailedElement<Label extends ApiBuiltStatus = ApiBuiltStatus> extends ApiPlannedElement {
-    constructor(detailedElement: Partial<ApiDetailedElement<Label>> = {}) {
-        super(detailedElement);
-        addInstantGetterAndSetterToApiModel(this, "builtAt", detailedElement.builtAt);
-        addInstantGetterAndSetterToApiModel(this, "fixedAt", detailedElement.fixedAt);
-        this.scanResult = detailedElement.scanResult;
-        if (isDeviationScanResult(this.scanResult)) {
-            this.scanResult.deviation = { ...new ApiElementDeviation(this.scanResult.deviation) };
-        }
-        if (detailedElement.fixedDeviation) {
-            this.fixedDeviation = {...new ApiElementDeviation(detailedElement.fixedDeviation)};
-        }
+  constructor(detailedElement: Partial<ApiDetailedElement<Label>> = {}) {
+    super(detailedElement);
+    addInstantGetterAndSetterToApiModel(this, "builtAt", detailedElement.builtAt);
+    addInstantGetterAndSetterToApiModel(this, "fixedAt", detailedElement.fixedAt);
+    this.scanResult = detailedElement.scanResult;
+    if (isDeviationScanResult(this.scanResult)) {
+      this.scanResult.deviation = { ...new ApiElementDeviation(this.scanResult.deviation) };
     }
+    if (detailedElement.fixedDeviation) {
+      this.fixedDeviation = { ...new ApiElementDeviation(detailedElement.fixedDeviation) };
+    }
+  }
 
-    scanResult?: ApiScannedElementTypeMap[Label];
-    builtAt?: number;
-    fixedAt?: number;
-    fixedDeviation?: ApiElementDeviation;
+  scanResult?: ApiScannedElementTypeMap[Label];
+  builtAt?: number;
+  fixedAt?: number;
+  fixedDeviation?: ApiElementDeviation;
 }
 
 export default ApiDetailedElement;

--- a/source/models/api/api_element_deviation.ts
+++ b/source/models/api/api_element_deviation.ts
@@ -1,17 +1,26 @@
-import {Vector3Like} from "./type_aliases";
-import {DeviationStatus} from "../enums";
-import {Vector3} from "three";
+import { Vector3 } from "three";
+
+import { DeviationStatus } from "../enums";
+
+import type { ModifyPartial, Vector3Like } from "type_aliases";
+
+export type ApiElementDeviationArgument = ModifyPartial<ApiElementDeviation, {
+  deviationVectorMeters: Vector3Like
+}>
 
 export class ApiElementDeviation {
-  deviationVectorMeters: Vector3Like;
+  deviationVectorMeters: Vector3;
   deviationMeters: number;
   status: DeviationStatus;
+  /** @deprecated This is now stored as obstructing/obstructed id pairs and will be ignored */
   clashing: boolean;
 
-  constructor(deviation: Partial<ApiElementDeviation> = {}) {
+  constructor(deviation: ApiElementDeviationArgument = {}) {
     let deviationVector: Vector3;
     if (deviation?.deviationVectorMeters) {
-      deviationVector = new Vector3(deviation.deviationVectorMeters.x, deviation.deviationVectorMeters.y, deviation.deviationVectorMeters.z);
+      deviationVector = new Vector3(deviation.deviationVectorMeters.x,
+        deviation.deviationVectorMeters.y,
+        deviation.deviationVectorMeters.z);
     } else {
       deviationVector = new Vector3();
     }

--- a/source/models/api/api_floor.ts
+++ b/source/models/api/api_floor.ts
@@ -1,17 +1,18 @@
+import { Matrix3 } from "three";
+
 import addInstantGetterAndSetterToApiModel from "../../mixins/add_instant_getter_and_setter_to_api_model";
 import addReadOnlyPropertiesToModel from "../../mixins/add_read_only_properties_to_model";
-import ApiConstructionGrid from "./api_construction_grid";
-import {DateLike, Matrix3Like, Modify, Vector2Like} from "./type_aliases";
-import ApiMatrix3 from "./api_matrix_3";
-import {Matrix3} from "three";
 import Matrix3Converter from "../../converters/matrix_3_converter";
 
-export interface ApiFloorArgument extends Partial<Modify<ApiFloor, {
+import type ApiConstructionGrid from "./api_construction_grid";
+import type ApiMatrix3 from "./api_matrix_3";
+import type { DateLike, Matrix3Like, ModifyPartial, Vector2Like } from "type_aliases";
+
+export type ApiFloorArgument = ModifyPartial<ApiFloor, {
   scanDate?: DateLike,
   photoAreaMinimapPixelToBimMinimapPixel?: Matrix3Like;
   bimMinimapToWorld?: Matrix3Like;
-}>> {
-}
+}>
 
 export class ApiFloor {
   constructor({
@@ -33,9 +34,10 @@ export class ApiFloor {
                 bimMinimapToWorld,
                 floorElevation,
                 globalOffsetYaw
-              }: ApiFloorArgument = {}) {
-    addInstantGetterAndSetterToApiModel(this, "scanDate");
-    addReadOnlyPropertiesToModel(this, {id, firebaseId, firebaseProjectId});
+              }: ApiFloorArgument = {})
+  {
+    addReadOnlyPropertiesToModel(this, { id, firebaseId, firebaseProjectId });
+    addInstantGetterAndSetterToApiModel(this, "scanDate", scanDate);
     let offsetVal: Vector2Like, photoMinimapToBimMinimapTransformVal: ApiMatrix3,
       bimMinimapToWorldTransformVal: ApiMatrix3;
     Object.defineProperties(this, {
@@ -45,7 +47,7 @@ export class ApiFloor {
         },
         set(val: Vector2Like) {
           if (val) {
-            offsetVal = {x: val.x, y: val.y};
+            offsetVal = { x: val.x, y: val.y };
           } else {
             offsetVal = null;
           }
@@ -137,7 +139,7 @@ export class ApiFloor {
   /**
    * An array of external identifiers of the capture datasets associated with this area.
    */
-  firebaseScanDatasetIds: Array<string> = [];
+  firebaseScanDatasetIds: string[];
 
   constructionGrid: ApiConstructionGrid | null = null;
   plannedElementCount: number | null = null;

--- a/source/models/api/api_grid_line.ts
+++ b/source/models/api/api_grid_line.ts
@@ -1,5 +1,6 @@
 import { Vector2 } from "three";
-import { Vector2Like } from "./type_aliases";
+
+import type { Vector2Like } from "type_aliases";
 
 export class ApiGridLine {
   constructor({ name, point1, point2 }: Partial<ApiGridLine>) {

--- a/source/models/api/api_groups.ts
+++ b/source/models/api/api_groups.ts
@@ -1,28 +1,29 @@
-import {addInstantGetterAndSetterToApiModel} from "../../mixins";
+import { addInstantGetterAndSetterToApiModel } from "../../mixins";
 
 export class ApiGroup {
-  id: number
-  name: string
+  id: number;
+  name: string;
   createdAt: number;
   createdBy: number;
   members: ApiGroupMember[];
   floorId: string;
+
   constructor({ id, name, createdAt, createdBy, members, floorId }: Partial<ApiGroup>) {
     this.id = id;
     this.name = name;
     this.createdBy = createdBy;
     this.members = members;
-    this.floorId = floorId
+    this.floorId = floorId;
     addInstantGetterAndSetterToApiModel(this, "createdAt", createdAt);
   }
 }
 
 
 export class ApiGroupMember {
-  id: number
-  groupId: number
-  memberType: string
-  elementId: string
+  id: number;
+  groupId: number;
+  memberType: string;
+  elementId: string;
 
   constructor({ id, groupId, memberType, elementId }: Partial<ApiGroupMember>) {
     this.id = id;

--- a/source/models/api/api_inspect_report.ts
+++ b/source/models/api/api_inspect_report.ts
@@ -1,18 +1,29 @@
-import {addInstantGetterAndSetterToApiModel, addReadOnlyPropertiesToModel} from "../../mixins";
-import {ApiInspectReportEntry} from "./api_inspect_report_entry";
-import ApiUser from "./api_user";
+import { addInstantGetterAndSetterToApiModel, addReadOnlyPropertiesToModel } from "../../mixins";
+import { ApiInspectReportEntry, ApiInspectReportEntryArgument } from "./api_inspect_report_entry";
+
+import type ApiUser from "./api_user";
+import { DateLike, ModifyPartial } from "type_aliases";
+
+export type ApiInspectReportArgument = ModifyPartial<ApiInspectReport, {
+  entries: ApiInspectReportEntryArgument[]
+  createdAt: DateLike
+  createdBy: Partial<ApiUser>
+}>
 
 export class ApiInspectReport {
-    constructor({ id, firebaseProjectId, name, entries, createdBy, createdAt }: Partial<ApiInspectReport>) {
-        addReadOnlyPropertiesToModel(this, { id, firebaseProjectId, createdBy });
-        this.name = name;
-        this.entries = !!entries ? entries : [];
-        addInstantGetterAndSetterToApiModel(this, "createdAt", createdAt);
-    }
-    readonly id: number;
-    readonly firebaseProjectId: string;
-    name: string;
-    entries: ApiInspectReportEntry[];
-    createdAt?: number;
-    createdBy?: ApiUser;
+  constructor({ id, firebaseProjectId, name, entries, createdBy, createdAt }: ApiInspectReportArgument) {
+    addReadOnlyPropertiesToModel(this, { id, firebaseProjectId, createdBy });
+    this.name = name;
+    this.entries = entries?.map(entry => new ApiInspectReportEntry(entry)) || [];
+    addInstantGetterAndSetterToApiModel(this, "createdAt", createdAt);
+  }
+
+  readonly id: number;
+  readonly firebaseProjectId: string;
+  name: string;
+  entries: ApiInspectReportEntry[];
+  createdAt?: number;
+  readonly createdBy?: ApiUser;
 }
+
+export default ApiInspectReport;

--- a/source/models/api/api_inspect_report_entry.ts
+++ b/source/models/api/api_inspect_report_entry.ts
@@ -1,32 +1,56 @@
-import {addInstantGetterAndSetterToApiModel, addReadOnlyPropertiesToModel} from "../../mixins";
-import ApiUser from "./api_user";
-import ApiCloudFile from "./api_cloud_file";
-import ApiView from "./api_view";
-import {ApiInspectReportEntryElement} from "./api_inspect_report_entry_element";
+import { addInstantGetterAndSetterToApiModel, addReadOnlyPropertiesToModel } from "../../mixins";
+import ApiInspectReportEntryElement from "./api_inspect_report_entry_element";
+
+import type ApiUser from "./api_user";
+import type ApiCloudFile from "./api_cloud_file";
+import type ApiView from "./api_view";
+import type { DateLike, ModifyPartial } from "type_aliases";
+
+export type ApiInspectReportEntryArgument = ModifyPartial<ApiInspectReportEntry, {
+  createdAt: DateLike
+  elements: Partial<ApiInspectReportEntryElement>[]
+}>
 
 export class ApiInspectReportEntry {
-    constructor({ id, reportId, name, view, screenshot, minimapFile, zoomedMinimapFile, elements, createdBy, createdAt, obstructingTrades, obstructedTrades }: Partial<ApiInspectReportEntry>) {
-        addReadOnlyPropertiesToModel(this, { id, reportId, createdBy });
-        addInstantGetterAndSetterToApiModel(this, "createdAt", createdAt);
-        this.name = name;
-        this.view = view;
-        this.screenshot = screenshot;
-        this.minimapFile = minimapFile;
-        this.zoomedMinimapFile = zoomedMinimapFile;
-        this.elements = elements;
-        this.obstructingTrades = obstructingTrades;
-        this.obstructedTrades = obstructedTrades;
-    }
-    readonly id: number;
-    readonly reportId: number;
-    name: string;
-    view: ApiView;
-    screenshot: ApiCloudFile;
-    minimapFile: ApiCloudFile;
-    zoomedMinimapFile: ApiCloudFile;
-    elements: ApiInspectReportEntryElement[];
-    obstructedTrades?: string[];
-    obstructingTrades?: string[]
-    createdAt?: number;
-    createdBy?: ApiUser;
+  constructor({
+                id,
+                reportId,
+                name,
+                view,
+                screenshot,
+                minimapFile,
+                zoomedMinimapFile,
+                elements,
+                createdBy,
+                createdAt,
+                obstructingTrades,
+                obstructedTrades
+              }: ApiInspectReportEntryArgument)
+  {
+    addReadOnlyPropertiesToModel(this, { id, reportId, createdBy });
+    addInstantGetterAndSetterToApiModel(this, "createdAt", createdAt);
+    this.name = name;
+    this.view = view;
+    this.screenshot = screenshot;
+    this.minimapFile = minimapFile;
+    this.zoomedMinimapFile = zoomedMinimapFile;
+    this.elements = elements?.map(element => new ApiInspectReportEntryElement(element)) || [];
+    this.obstructingTrades = obstructingTrades || [];
+    this.obstructedTrades = obstructedTrades || [];
+  }
+
+  readonly id: number;
+  readonly reportId: number;
+  name: string;
+  view: ApiView;
+  screenshot: ApiCloudFile;
+  minimapFile: ApiCloudFile;
+  zoomedMinimapFile: ApiCloudFile;
+  elements: ApiInspectReportEntryElement[];
+  obstructedTrades?: string[];
+  obstructingTrades?: string[];
+  createdAt?: number;
+  createdBy?: ApiUser;
 }
+
+export default ApiInspectReportEntry;

--- a/source/models/api/api_inspect_report_entry_element.ts
+++ b/source/models/api/api_inspect_report_entry_element.ts
@@ -1,26 +1,29 @@
-import {Vector3} from "three";
+import type { Vector3 } from "three";
 
 export class ApiInspectReportEntryElement {
-    constructor({masterformatCode, builtStatus, deviationVectorMeters, globalId, name}) {
-        this.masterformatCode = masterformatCode;
-        this.builtStatus = builtStatus;
-        this.deviationVectorMeters = deviationVectorMeters
-        this.globalId = globalId;
-        this.name = name;
-    }
-    masterformatCode: string;
-    builtStatus: string;
-    deviationVectorMeters: Vector3;
-    globalId: string;
-    name: string;
+  constructor({ masterformatCode, builtStatus, deviationVectorMeters, globalId, name }: Partial<ApiInspectReportEntryElement> = {}) {
+    this.masterformatCode = masterformatCode;
+    this.builtStatus = builtStatus;
+    this.deviationVectorMeters = deviationVectorMeters;
+    this.globalId = globalId;
+    this.name = name;
+  }
 
-    static plannedBuildingElementToApiInspectReportEntry(element, level1Masterformat): ApiInspectReportEntryElement {
-        return new ApiInspectReportEntryElement({
-            masterformatCode: level1Masterformat,
-            globalId: element.globalId,
-            deviationVectorMeters: element.deviationVectorMeters,
-            builtStatus: element.builtStatus,
-            name: element.name
-        })
-    }
+  masterformatCode: string;
+  builtStatus: string;
+  deviationVectorMeters: Vector3;
+  globalId: string;
+  name: string;
+
+  static plannedBuildingElementToApiInspectReportEntry(element, level1Masterformat): ApiInspectReportEntryElement {
+    return new ApiInspectReportEntryElement({
+      masterformatCode: level1Masterformat,
+      globalId: element.globalId,
+      deviationVectorMeters: element.deviationVectorMeters,
+      builtStatus: element.builtStatus,
+      name: element.name
+    });
+  }
 }
+
+export default ApiInspectReportEntryElement;

--- a/source/models/api/api_integration_credentials.ts
+++ b/source/models/api/api_integration_credentials.ts
@@ -1,8 +1,9 @@
 import addInstantGetterAndSetterToApiModel from "../../mixins/add_instant_getter_and_setter_to_api_model";
-import {DateLike, ModifyPartial} from "./type_aliases";
-import {ApiIntegrationCredentialsType} from "../enums";
 
-export type ApiIntegrationCredentialsArgs = ModifyPartial<ApiIntegrationCredentials, {
+import type { DateLike, ModifyPartial } from "./type_aliases";
+import type { ApiIntegrationCredentialsType } from "../enums";
+
+export type ApiIntegrationCredentialsArgument = ModifyPartial<ApiIntegrationCredentials, {
   createdAt?: DateLike,
   modifiedAt?: DateLike
 }>;
@@ -19,7 +20,8 @@ export class ApiIntegrationCredentials {
                 firebaseProjectId,
                 authorId,
                 encryptedCredentials
-              }: ApiIntegrationCredentialsArgs) {
+              }: ApiIntegrationCredentialsArgument)
+  {
     this.id = id;
     this.username = username;
     this.password = password;

--- a/source/models/api/api_integration_project.ts
+++ b/source/models/api/api_integration_project.ts
@@ -1,7 +1,8 @@
 import addInstantGetterAndSetterToApiModel from "../../mixins/add_instant_getter_and_setter_to_api_model";
-import {DateLike, ModifyPartial} from "./type_aliases";
 
-export type ApiIntegrationProjectArgs = ModifyPartial<ApiIntegrationProject, {
+import type { DateLike, ModifyPartial } from "./type_aliases";
+
+export type ApiIntegrationProjectArgument = ModifyPartial<ApiIntegrationProject, {
   createdAt?: DateLike,
   modifiedAt?: DateLike
 }>;
@@ -14,7 +15,8 @@ export class ApiIntegrationProject {
                 integrationCredentialsId,
                 externalId,
                 externalName
-              }: ApiIntegrationProjectArgs) {
+              }: ApiIntegrationProjectArgument)
+  {
     this.id = id;
     this.integrationCredentialsId = integrationCredentialsId;
     this.externalId = externalId;

--- a/source/models/api/api_invitation.ts
+++ b/source/models/api/api_invitation.ts
@@ -1,4 +1,4 @@
-import {UserRole} from "../enums";
+import type { UserRole } from "../enums";
 
 export class ApiInvitation {
   resourceName: string;

--- a/source/models/api/api_masterformat_progress.ts
+++ b/source/models/api/api_masterformat_progress.ts
@@ -1,8 +1,8 @@
 import addInstantGetterAndSetterToApiModel from "../../mixins/add_instant_getter_and_setter_to_api_model";
 import ApiMasterformat from "./api_masterformat";
-import {DateLike} from "./type_aliases";
+import { DateLike } from "./type_aliases";
 
-export type ApiMasterformatProgressArgs = Partial<ApiMasterformatProgress>;
+export type ApiMasterformatProgressArgument = Partial<ApiMasterformatProgress>;
 
 export class ApiMasterformatProgress {
     constructor({
@@ -11,7 +11,7 @@ export class ApiMasterformatProgress {
                     scanDate,
                     createdAt,
                     customTradeCode
-                }: ApiMasterformatProgressArgs) {
+                }: ApiMasterformatProgressArgument) {
         addInstantGetterAndSetterToApiModel(this, "scanDate");
         addInstantGetterAndSetterToApiModel(this, "createdAt");
         if (masterformat) {
@@ -32,3 +32,5 @@ export class ApiMasterformatProgress {
     createdAt: number | null | DateLike = null;
     customTradeCode: string | null = null;
 }
+
+export default ApiMasterformatProgress;

--- a/source/models/api/api_organization.ts
+++ b/source/models/api/api_organization.ts
@@ -52,7 +52,7 @@ export class ApiOrganization {
   contactPhoneNumber?: string | null = null;
   name?: string | null = null;
   notes?: string | null = null;
-  firebaseProjectIds: Array<string> = [];
+  firebaseProjectIds: string[];
   multivistaEmail?: string | null = null;
   multivistaPassword?: string | null = null;
 }

--- a/source/models/api/api_photo_location.ts
+++ b/source/models/api/api_photo_location.ts
@@ -1,15 +1,16 @@
-import {Matrix4Like, DateLike, ModifyPartial} from "./type_aliases";
-import PhotoProjectionType from "../enums/photo_projection_type";
-import ApiCloudFile from "./api_cloud_file";
-import ApiPhotoLocation3d from "./api_photo_location_3d";
-import {PhotoRotationType} from "../enums";
 import addInstantGetterAndSetterToApiModel from "../../mixins/add_instant_getter_and_setter_to_api_model";
 
-export type ApiPhotoLocationArgs = ModifyPartial<ApiPhotoLocation, {
-  createdAt?: DateLike,
-  updatedAt?: DateLike,
-  originalTimestamp?: DateLike
-  deletedAt?: DateLike
+import type ApiCloudFile from "./api_cloud_file";
+import type ApiPhotoLocation3d from "./api_photo_location_3d";
+import type PhotoProjectionType from "../enums/photo_projection_type";
+import type { DateLike, Matrix4Like, ModifyPartial } from "./type_aliases";
+import type { PhotoRotationType } from "../enums";
+
+export type ApiPhotoLocationArgument = ModifyPartial<ApiPhotoLocation, {
+  createdAt: DateLike,
+  updatedAt: DateLike,
+  originalTimestamp: DateLike
+  deletedAt: DateLike
 }>;
 
 export class ApiPhotoLocation {
@@ -30,11 +31,8 @@ export class ApiPhotoLocation {
                 updatedAt,
                 originalTimestamp,
                 deletedAt
-              }: ApiPhotoLocationArgs = {}) {
-    addInstantGetterAndSetterToApiModel(this, "createdAt", createdAt);
-    addInstantGetterAndSetterToApiModel(this, "updatedAt", updatedAt);
-    addInstantGetterAndSetterToApiModel(this, "originalTimestamp", originalTimestamp);
-    addInstantGetterAndSetterToApiModel(this, "deletedAt", deletedAt);
+              }: ApiPhotoLocationArgument = {})
+  {
     this.id = id;
     this.photoAreaId = photoAreaId;
     this.photoSessionId = photoSessionId;
@@ -47,16 +45,16 @@ export class ApiPhotoLocation {
     this.bimLocation = bimLocation;
     this.yawOffset = yawOffset;
     this.rotationType = rotationType;
+    addInstantGetterAndSetterToApiModel(this, "createdAt", createdAt);
+    addInstantGetterAndSetterToApiModel(this, "updatedAt", updatedAt);
+    addInstantGetterAndSetterToApiModel(this, "originalTimestamp", originalTimestamp);
+    addInstantGetterAndSetterToApiModel(this, "deletedAt", deletedAt);
   }
 
   readonly id: number;
   readonly photoAreaId: number;
   readonly photoSessionId?: number;
   readonly file: ApiCloudFile;
-  readonly createdAt: number;
-  readonly updatedAt?: number;
-  readonly originalTimestamp?: number;
-  readonly deletedAt?: number;
   minimapX: number;
   minimapY: number;
   minimapBearing: number;
@@ -65,6 +63,10 @@ export class ApiPhotoLocation {
   bimLocation: ApiPhotoLocation3d;
   yawOffset: number = null;
   rotationType: PhotoRotationType;
+  readonly createdAt: number;
+  readonly updatedAt?: number;
+  readonly originalTimestamp?: number;
+  readonly deletedAt?: number;
 }
 
 export default ApiPhotoLocation;

--- a/source/models/api/api_photo_location_3d.ts
+++ b/source/models/api/api_photo_location_3d.ts
@@ -1,6 +1,7 @@
-import {Vector3Like, Vector4Like} from "./type_aliases";
 import addReadOnlyPropertiesToModel from "../../mixins/add_read_only_properties_to_model";
-import {ApiQuaternion} from "./api_quaternion";
+import { ApiQuaternion } from "./api_quaternion";
+
+import type { Vector3Like, Vector4Like } from "./type_aliases";
 
 export type ApiPhotoLocationProperties = {
   id: number,
@@ -8,7 +9,7 @@ export type ApiPhotoLocationProperties = {
   orientation: ApiQuaternion
 }
 
-export type ApiPhotoLocation3dArguments = {
+export type ApiPhotoLocation3dArgument = {
   id: number,
   position: Vector3Like,
   orientation: Vector4Like
@@ -18,11 +19,13 @@ export class ApiPhotoLocation3d {
   readonly id: number;
   position: Vector3Like;
   orientation: ApiQuaternion;
+
   constructor({
-        id,
-        position,
-        orientation
-      }: ApiPhotoLocation3dArguments ) {
+                id,
+                position,
+                orientation
+              }: ApiPhotoLocation3dArgument)
+  {
     addReadOnlyPropertiesToModel(this, { id });
     this.position = position;
     this.orientation = ApiQuaternion.create(orientation);

--- a/source/models/api/api_photo_session.ts
+++ b/source/models/api/api_photo_session.ts
@@ -1,15 +1,15 @@
-import addReadOnlyPropertiesToModel from "../../mixins/add_read_only_properties_to_model";
-import { DateLike, ModifyPartial } from "./type_aliases";
 import addInstantGetterAndSetterToApiModel from "../../mixins/add_instant_getter_and_setter_to_api_model";
+import addReadOnlyPropertiesToModel from "../../mixins/add_read_only_properties_to_model";
 
-export type ApiPhotoSessionArgs = ModifyPartial<ApiPhotoSession, {
+import type { DateLike, ModifyPartial } from "./type_aliases";
+
+export type ApiPhotoSessionArgument = ModifyPartial<ApiPhotoSession, {
   sessionDate?: DateLike,
   deletedAt?: DateLike
-  externalId?: string
 }>
 
 export class ApiPhotoSession {
-  constructor({ id, photoAreaId, sessionDate, deletedAt, externalId }: ApiPhotoSessionArgs = {}) {
+  constructor({ id, photoAreaId, sessionDate, deletedAt, externalId }: ApiPhotoSessionArgument = {}) {
     addReadOnlyPropertiesToModel(this, { id, photoAreaId });
     addInstantGetterAndSetterToApiModel(this, "sessionDate", sessionDate);
     addInstantGetterAndSetterToApiModel(this, "deletedAt", deletedAt);

--- a/source/models/api/api_pipeline.ts
+++ b/source/models/api/api_pipeline.ts
@@ -1,12 +1,13 @@
-import { DateLike, ModifyPartial } from "./type_aliases";
-import addReadOnlyPropertiesToModel from "../../mixins/add_read_only_properties_to_model";
 import addInstantGetterAndSetterToApiModel from "../../mixins/add_instant_getter_and_setter_to_api_model";
-import {PipelineName, RunningProcessStatus} from "../enums";
+import addReadOnlyPropertiesToModel from "../../mixins/add_read_only_properties_to_model";
 
-export interface ApiPipelineArgument extends ModifyPartial<ApiPipeline, {
+import type { DateLike, ModifyPartial } from "./type_aliases";
+import type { PipelineName, RunningProcessStatus } from "../enums";
+
+export type ApiPipelineArgument = ModifyPartial<ApiPipeline, {
   startTime?: DateLike
   endTime?: DateLike
-}> {}
+}>
 
 export class ApiPipeline {
   constructor({
@@ -22,7 +23,8 @@ export class ApiPipeline {
                 firebaseScanDatasetId,
                 options,
                 status
-              }: ApiPipelineArgument = {}) {
+              }: ApiPipelineArgument = {})
+  {
     addReadOnlyPropertiesToModel(this, { id });
     addInstantGetterAndSetterToApiModel(this, "startTime");
     addInstantGetterAndSetterToApiModel(this, "endTime");

--- a/source/models/api/api_planned_element.ts
+++ b/source/models/api/api_planned_element.ts
@@ -1,7 +1,8 @@
-import { UniformatId } from "uniformat";
-import ApiElementDeviation from "./api_element_deviation";
 import { addInstantGetterAndSetterToApiModel } from "../../mixins";
-import { DateLike, ModifyPartial } from "type_aliases";
+
+import type ApiElementDeviation from "./api_element_deviation";
+import type { DateLike, ModifyPartial } from "type_aliases";
+import type { UniformatId } from "uniformat";
 
 type ApiPlannedElementArgument = ModifyPartial<ApiPlannedElement, { builtAt: DateLike, fixedAt: DateLike }>
 

--- a/source/models/api/api_progress_category.ts
+++ b/source/models/api/api_progress_category.ts
@@ -1,4 +1,4 @@
-import { UniformatId } from "uniformat";
+import type { UniformatId } from "uniformat";
 
 export class ApiProgressCategory {
   uniformatId: UniformatId;

--- a/source/models/api/api_progress_scan_dataset.ts
+++ b/source/models/api/api_progress_scan_dataset.ts
@@ -1,4 +1,4 @@
-import ApiProgressCategory from "./api_progress_category";
+import type ApiProgressCategory from "./api_progress_category";
 
 export class ApiProgressScanDataset {
   id: number;

--- a/source/models/api/api_project.ts
+++ b/source/models/api/api_project.ts
@@ -1,18 +1,20 @@
 import addInstantGetterAndSetterToApiModel from "../../mixins/add_instant_getter_and_setter_to_api_model";
 import addReadOnlyPropertiesToModel from "../../mixins/add_read_only_properties_to_model";
-import ApiProjectCostAnalysisProgress from "./api_project_cost_analysis_progress";
+import ApiProjectReport, { ApiProjectReportArgument } from "./api_project_report";
 import SystemOfMeasurement, { IMPERIAL } from "../enums/system_of_measurement";
-import { DateLike, Modify } from "./type_aliases";
-import ApiProjectReport from "./api_project_report";
-import {ApiTeamMember} from "./api_team_member";
-import { ApiProjectSettings } from "./api_project_settings";
-import {ApiMasterformatProgress} from "./api_masterformat_progress";
 
-export interface ApiProjectArgument extends Partial<Modify<ApiProject, {
-  archivedAt?: DateLike
-  startDate?: DateLike
-  endDate?: DateLike
-}>> {}
+import type ApiProjectCostAnalysisProgress from "./api_project_cost_analysis_progress";
+import type ApiTeamMember from "./api_team_member";
+import type ApiMasterformatProgress from "./api_masterformat_progress";
+import type ApiProjectSettings from "./api_project_settings";
+import type { DateLike, ModifyPartial } from "./type_aliases";
+
+export type ApiProjectArgument = ModifyPartial<ApiProject, {
+  archivedAt: DateLike
+  startDate: DateLike
+  endDate: DateLike
+  projectReports: ApiProjectReportArgument[]
+}>
 
 export class ApiProject {
   constructor({
@@ -48,10 +50,11 @@ export class ApiProject {
                 settings,
                 baselineScheduleDate,
                 currentScheduleDate
-              }: ApiProjectArgument = {}) {
-    addInstantGetterAndSetterToApiModel(this, "startDate");
-    addInstantGetterAndSetterToApiModel(this, "endDate");
-    addInstantGetterAndSetterToApiModel(this, "archivedAt");
+              }: ApiProjectArgument = {})
+  {
+    addInstantGetterAndSetterToApiModel(this, "startDate", startDate);
+    addInstantGetterAndSetterToApiModel(this, "endDate", endDate);
+    addInstantGetterAndSetterToApiModel(this, "archivedAt", archivedAt);
 
     addReadOnlyPropertiesToModel(this, { firebaseId, clientAccountId, id });
 
@@ -73,15 +76,9 @@ export class ApiProject {
     this.baselineProjectMasterformatProgresses = baselineProjectMasterformatProgresses || [];
     this.currentProjectMasterformatProgresses = currentProjectMasterformatProgresses || [];
     this.costAnalysisProgresses = costAnalysisProgresses || [];
-    this.projectReports = projectReports || [];
+    this.projectReports = projectReports?.map(report => new ApiProjectReport(report)) || [];
 
     this.systemOfMeasurement = systemOfMeasurement || IMPERIAL;
-    // @ts-ignore
-    this.endDate = endDate || null;
-    // @ts-ignore
-    this.startDate = startDate || null;
-    // @ts-ignore
-    this.archivedAt = archivedAt || null;
     this.generateMasterformatProgressEnabled = generateMasterformatProgressEnabled;
     this.integrationProjectId = integrationProjectId;
     this.teamMembers = teamMembers;
@@ -94,11 +91,11 @@ export class ApiProject {
   readonly firebaseId: string;
   readonly clientAccountId: string;
   name: string;
-  scannedProjectMasterformatProgresses: Array<ApiMasterformatProgress> = [];
-  baselineProjectMasterformatProgresses: Array<ApiMasterformatProgress> = [];
-  currentProjectMasterformatProgresses: Array<ApiMasterformatProgress> = [];
-  costAnalysisProgresses: Array<ApiProjectCostAnalysisProgress> = [];
-  projectReports: Array<ApiProjectReport>;
+  scannedProjectMasterformatProgresses: ApiMasterformatProgress[];
+  baselineProjectMasterformatProgresses: ApiMasterformatProgress[];
+  currentProjectMasterformatProgresses: ApiMasterformatProgress[];
+  costAnalysisProgresses: ApiProjectCostAnalysisProgress[];
+  projectReports: ApiProjectReport[];
   defaultFirebaseFloorId: string | null = null;
   firebaseFloorIds: string[] = [];
   addressLine1: string | null = null;

--- a/source/models/api/api_project_area.ts
+++ b/source/models/api/api_project_area.ts
@@ -1,6 +1,7 @@
-import ApiProjectAreaWorkPackage from "./api_project_area_work_package";
 import { addReadOnlyPropertiesToModel } from "../../mixins";
 import { ApiProjectAreaProgress } from "./api_project_summary";
+
+import type ApiProjectAreaWorkPackage from "./api_project_area_work_package";
 
 export class ApiProjectArea {
   readonly id: number;

--- a/source/models/api/api_project_area_work_package.ts
+++ b/source/models/api/api_project_area_work_package.ts
@@ -12,7 +12,18 @@ export class ApiProjectAreaWorkPackage {
   completion: string;
 
 
-  constructor({ id, projectAreaId, projectWorkPackageId, workPackageId, status, expectedStart, expectedCompletion, start, completion }: Partial<ApiProjectAreaWorkPackage>) {
+  constructor({
+                id,
+                projectAreaId,
+                projectWorkPackageId,
+                workPackageId,
+                status,
+                expectedStart,
+                expectedCompletion,
+                start,
+                completion
+              }: Partial<ApiProjectAreaWorkPackage>)
+  {
     addReadOnlyPropertiesToModel(this, { id, projectAreaId, projectWorkPackageId, workPackageId });
     this.status = status;
     this.expectedStart = expectedStart;

--- a/source/models/api/api_project_cost_analysis_progress.ts
+++ b/source/models/api/api_project_cost_analysis_progress.ts
@@ -1,6 +1,7 @@
 import addInstantGetterAndSetterToApiModel from "../../mixins/add_instant_getter_and_setter_to_api_model";
 import addReadOnlyPropertiesToModel from "../../mixins/add_read_only_properties_to_model";
-import { DateLike, Modify } from "./type_aliases";
+
+import type { DateLike, Modify } from "./type_aliases";
 
 export type ApiProjectCostAnalysisProgressArgument = Partial<Modify<ApiProjectCostAnalysisProgress, {
     analysisDate?: DateLike

--- a/source/models/api/api_project_report.ts
+++ b/source/models/api/api_project_report.ts
@@ -1,21 +1,27 @@
-import ApiProjectReportVersion from "./api_project_report_version";
+import ApiProjectReportVersion, { ApiProjectReportVersionArgument } from "./api_project_report_version";
+
+import type { ModifyPartial } from "type_aliases";
+
+export type ApiProjectReportArgument = ModifyPartial<ApiProjectReport, {
+  reportVersions: ApiProjectReportVersionArgument[];
+}>
 
 export class ApiProjectReport {
-    constructor({id, type, name, url, subcontractorId, reportVersions}: Partial<ApiProjectReport> = {}) {
-        this.id = id;
-        this.type = type;
-        this.name = name;
-        this.url = url;
-        this.reportVersions = reportVersions;
-        this.subcontractorId = subcontractorId;
-    }
+  constructor({ id, type, name, url, subcontractorId, reportVersions }: ApiProjectReportArgument = {}) {
+    this.id = id;
+    this.type = type;
+    this.name = name;
+    this.url = url;
+    this.reportVersions = reportVersions?.map(version => new ApiProjectReportVersion(version)) || [];
+    this.subcontractorId = subcontractorId;
+  }
 
-    id: number;
-    type: string;
-    name: string;
-    url: string;
-    reportVersions: ApiProjectReportVersion[];
-    subcontractorId: number;
+  id: number;
+  type: string;
+  name: string;
+  url: string;
+  reportVersions: ApiProjectReportVersion[];
+  subcontractorId: number;
 }
 
 export default ApiProjectReport;

--- a/source/models/api/api_project_report_version.ts
+++ b/source/models/api/api_project_report_version.ts
@@ -1,22 +1,26 @@
 import addDateGetterAndSetterToDomainModel from "../../mixins/add_date_getter_and_setter_to_domain_model";
 
+import type { DateLike, ModifyPartial } from "type_aliases";
+
+export type ApiProjectReportVersionArgument = ModifyPartial<ApiProjectReportVersion, {
+  reportDate: DateLike
+}>
+
 export class ApiProjectReportVersion {
-    constructor({id, projectReportId, reportDate, note, url}: Partial<ApiProjectReportVersion> = {}) {
-        addDateGetterAndSetterToDomainModel(this, "reportDate");
+  constructor({ id, projectReportId, reportDate, note, url }: ApiProjectReportVersionArgument = {}) {
+    addDateGetterAndSetterToDomainModel(this, "reportDate", reportDate);
 
-        this.id = id;
-        this.projectReportId = projectReportId;
-        this.note = note;
-        this.url = url;
-        // @ts-ignore
-        this.reportDate = reportDate || null;
-    }
+    this.id = id;
+    this.projectReportId = projectReportId;
+    this.note = note;
+    this.url = url;
+  }
 
-    id: number;
-    projectReportId: number;
-    reportDate: Date;
-    note: string;
-    url: string;
+  id: number;
+  projectReportId: number;
+  reportDate: Date;
+  note: string;
+  url: string;
 }
 
 export default ApiProjectReportVersion;

--- a/source/models/api/api_project_settings.ts
+++ b/source/models/api/api_project_settings.ts
@@ -8,3 +8,5 @@ export class ApiProjectSettings {
   autoScanAnalysis: boolean;
   autoCalculateProgress: boolean;
 }
+
+export default ApiProjectSettings;

--- a/source/models/api/api_project_summary.ts
+++ b/source/models/api/api_project_summary.ts
@@ -2,7 +2,7 @@ import ApiCloudFile, { ApiCloudFileArgument } from "./api_cloud_file";
 
 import type { ModifyPartial } from "type_aliases";
 
-export type ApiProjectSummaryArg = ModifyPartial<ApiProjectSummary, {
+export type ApiProjectSummaryArgument = ModifyPartial<ApiProjectSummary, {
   model: ApiCloudFileArgument
 }>
 
@@ -10,7 +10,7 @@ export class ApiProjectSummary {
   readonly model: ApiCloudFile;
   projectAreaIds: number[];
 
-  constructor({ model, projectAreaIds }: ApiProjectSummaryArg = {}) {
+  constructor({ model, projectAreaIds }: ApiProjectSummaryArgument = {}) {
     this.model = new ApiCloudFile(model);
     this.projectAreaIds = projectAreaIds || [];
   }

--- a/source/models/api/api_project_work_package.ts
+++ b/source/models/api/api_project_work_package.ts
@@ -1,17 +1,22 @@
-import { ProjectWorkPackageType } from "../enums";
+import type { ProjectWorkPackageType } from "../enums";
 
+/**
+ * @deprecated Use {@link ApiWorkPackage} instead.
+ */
 export class ApiProjectWorkPackage {
-    id?: number
-    name: string
-    ordinal: number
-    type?: ProjectWorkPackageType
-    masterformatCodes?: string[];
+  id?: number;
+  name: string;
+  ordinal: number;
+  type?: ProjectWorkPackageType;
+  masterformatCodes?: string[];
 
-    constructor({id, name, ordinal, type, masterformatCodes} : Partial<ApiProjectWorkPackage> = {}) {
-        this.id = id;
-        this.name = name;
-        this.ordinal = ordinal;
-        this.type = type;
-        this.masterformatCodes = masterformatCodes;
-    }
+  constructor({ id, name, ordinal, type, masterformatCodes }: Partial<ApiProjectWorkPackage> = {}) {
+    this.id = id;
+    this.name = name;
+    this.ordinal = ordinal;
+    this.type = type;
+    this.masterformatCodes = masterformatCodes;
+  }
 }
+
+export default ApiProjectWorkPackage;

--- a/source/models/api/api_project_work_package_cost.ts
+++ b/source/models/api/api_project_work_package_cost.ts
@@ -1,18 +1,19 @@
 import addReadOnlyPropertiesToModel from "../../mixins/add_read_only_properties_to_model";
 
-export class ApiProjectWorkPackageCost{
-    constructor({id, name, captured, planned, modeled}) {
-        addReadOnlyPropertiesToModel(this, {id});
-        this.name = name;
-        this.captured = captured;
-        this.planned = planned;
-        this.modeled = modeled;
-    }
-    id: number;
-    name: string;
-    captured: number;
-    planned: number;
-    modeled: number;
+export class ApiProjectWorkPackageCost {
+  constructor({ id, name, captured, planned, modeled }: Partial<ApiProjectWorkPackageCost> = {}) {
+    addReadOnlyPropertiesToModel(this, { id });
+    this.name = name;
+    this.captured = captured;
+    this.planned = planned;
+    this.modeled = modeled;
+  }
+
+  readonly id: number;
+  name: string;
+  captured: number;
+  planned: number;
+  modeled: number;
 }
 
 export default ApiProjectWorkPackageCost;

--- a/source/models/api/api_quaternion.ts
+++ b/source/models/api/api_quaternion.ts
@@ -31,3 +31,5 @@ export function isApiQuaternion(type: any): type is ApiQuaternion {
     && Number.isFinite(type.c)
     && Number.isFinite(type.d);
 }
+
+export default ApiQuaternion;

--- a/source/models/api/api_query_resource.ts
+++ b/source/models/api/api_query_resource.ts
@@ -2,3 +2,5 @@ export class ApiQueryResource {
   id: number;
   queriedIds: string[];
 }
+
+export default ApiQueryResource;

--- a/source/models/api/api_recipe.ts
+++ b/source/models/api/api_recipe.ts
@@ -1,55 +1,53 @@
-import { Modify } from "./type_aliases";
 import addReadOnlyPropertiesToModel from "../../mixins/add_read_only_properties_to_model";
 
-export interface ApiRecipeArgument extends Partial<Modify<ApiRecipe, {
-    name?: string | null
-    isEnabled?: boolean | null
-    modeledCode?: string | null
-    steps?: ApiRecipeStep[] | null
-}>> {
-}
+import type { ModifyPartial } from "type_aliases";
+
+export type ApiRecipeArgument = ModifyPartial<ApiRecipe, {
+  steps?: Partial<ApiRecipeStep>[] | null
+}>
 
 export class ApiRecipe {
-    readonly id: number
-    readonly projectFirebaseId?: string
-    name: string
-    isEnabled: boolean
-    modeledCode?: string
-    steps?: ApiRecipeStep[]
+  readonly id: number;
+  readonly firebaseProjectId?: string;
+  name: string;
+  isEnabled: boolean;
+  modeledCode?: string;
+  steps?: ApiRecipeStep[];
 
-    constructor({id, projectFirebaseId, name, isEnabled, modeledCode, steps}: ApiRecipeArgument) {
-        addReadOnlyPropertiesToModel(this, {id, projectFirebaseId});
-        this.name = name;
-        this.isEnabled = isEnabled || false;
-        this.modeledCode = modeledCode;
-        this.steps = steps || [];
-    }
-}
-
-export interface ApiRecipeStepArgument extends Partial<Modify<ApiRecipeStep, {
-    ordinal: number
-    name?: string | null
-    code?: string | null
-    partialProgressPercent?: number | null
-}>> {
+  constructor({ id, firebaseProjectId, name, isEnabled, modeledCode, steps }: ApiRecipeArgument) {
+    addReadOnlyPropertiesToModel(this, { id, firebaseProjectId });
+    this.name = name;
+    this.isEnabled = isEnabled || false;
+    this.modeledCode = modeledCode;
+    this.steps = steps?.map(step => new ApiRecipeStep(step)) || [];
+  }
 }
 
 export class ApiRecipeStep {
-    readonly id: number
-    readonly recipeId: number
-    readonly globalRecipeStepId: number
-    name: string
-    code: string
-    ordinal: number
-    partialProgressPercent: number
+  readonly id: number;
+  readonly recipeId: number;
+  readonly globalRecipeStepId: number;
+  name: string;
+  code: string;
+  ordinal: number;
+  partialProgressPercent: number;
 
-    constructor({ id, recipeId, globalRecipeStepId, ordinal, name, code, partialProgressPercent }: ApiRecipeStepArgument) {
-        addReadOnlyPropertiesToModel(this, { id, recipeId, globalRecipeStepId });
-        this.ordinal = ordinal;
-        this.name = name || null;
-        this.code = code || null;
-        this.partialProgressPercent = partialProgressPercent || 0.0;
-    }
+  constructor({
+                id,
+                recipeId,
+                globalRecipeStepId,
+                ordinal,
+                name,
+                code,
+                partialProgressPercent
+              }: Partial<ApiRecipeStep>)
+  {
+    addReadOnlyPropertiesToModel(this, { id, recipeId, globalRecipeStepId });
+    this.ordinal = ordinal;
+    this.name = name || null;
+    this.code = code || null;
+    this.partialProgressPercent = partialProgressPercent || 0.0;
+  }
 }
 
 export default ApiRecipe;

--- a/source/models/api/api_running_process.ts
+++ b/source/models/api/api_running_process.ts
@@ -1,20 +1,21 @@
-import ProcessStatus from "../enums/process_status";
-import {DateLike, ModifyPartial} from "./type_aliases";
 import addInstantGetterAndSetterToApiModel from "../../mixins/add_instant_getter_and_setter_to_api_model";
 
-export interface ApiRunningProcessArgs extends ModifyPartial<ApiRunningProcess, {
+import type ProcessStatus from "../enums/process_status";
+import type { DateLike, ModifyPartial } from "./type_aliases";
+
+export type ApiRunningProcessArgument = ModifyPartial<ApiRunningProcess, {
   startDate?: DateLike
   endDate?: DateLike
-}> { }
+}>
 
 export class ApiRunningProcess {
-  constructor({id, name, status, startDate, endDate, message}: ApiRunningProcessArgs = {}) {
+  constructor({ id, name, status, startDate, endDate, message }: ApiRunningProcessArgument = {}) {
     this.id = id;
     this.name = name;
     this.status = status;
-    this.message = message;
     addInstantGetterAndSetterToApiModel(this, "startDate", startDate);
     addInstantGetterAndSetterToApiModel(this, "endDate", endDate);
+    this.message = message;
   }
 
   id: number;

--- a/source/models/api/api_scan_dataset.ts
+++ b/source/models/api/api_scan_dataset.ts
@@ -1,19 +1,20 @@
 import { Matrix4 } from "three";
+
 import addInstantGetterAndSetterToApiModel from "../../mixins/add_instant_getter_and_setter_to_api_model";
 import addReadOnlyPropertiesToModel from "../../mixins/add_read_only_properties_to_model";
-import ApiMatrix4 from "./api_matrix_4";
 import Matrix4Converter from "../../converters/matrix_4_converter";
-import { DateLike, ModifyPartial } from "type_aliases";
+
+import type ApiMatrix4 from "./api_matrix_4";
+import type { DateLike, ModifyPartial } from "type_aliases";
 
 export type ApiScanDatasetArgument = ModifyPartial<ApiScanDataset, {
-  coarseAlignmentMatrix?: ApiMatrix4 | Matrix4 | string | null
-  fineAlignmentMatrix?: ApiMatrix4 | Matrix4 | string | null
-  scanDate?: DateLike,
-  qaStarted?: DateLike,
-  qaComplete?: DateLike,
-  analysisCompleted?: DateLike,
-  manualAnalysisSkipped?: DateLike,
-  scanDateString?: string,
+  coarseAlignmentMatrix: ApiMatrix4 | Matrix4 | string | null
+  fineAlignmentMatrix: ApiMatrix4 | Matrix4 | string | null
+  scanDate: DateLike,
+  qaStarted: DateLike,
+  qaComplete: DateLike,
+  analysisCompleted: DateLike,
+  manualAnalysisSkipped: DateLike,
 }>
 
 export enum ApiScanDatasetQaState {

--- a/source/models/api/api_scandataset_stats.ts
+++ b/source/models/api/api_scandataset_stats.ts
@@ -1,55 +1,64 @@
-import {addInstantGetterAndSetterToApiModel} from "../../mixins";
+import { addInstantGetterAndSetterToApiModel } from "../../mixins";
+
+import type { DateLike, ModifyPartial } from "type_aliases";
+
+export type ApiScanDatasetStatsArgument = ModifyPartial<ApiScanDatasetStats, {
+  pipelineStartTime: DateLike;
+  pipelineEndTime: DateLike;
+  qaCompleteTime: DateLike;
+  qaStartTime: DateLike;
+  realityCaptureUploadedOn: DateLike;
+}>
+
 
 export class ApiScanDatasetStats {
-   organizationName: string;
-   scanDatasetId: number;
-   projectName: string;
-   floor: string;
-   scanDatasetName: string;
-   pipelineStartTime: Date;
-   pipelineEndTime: Date;
-   pipelineStatus: string;
-   qaCompleteTime: Date;
-   qaStartTime: Date;
-   squareFootage: number;
+  constructor({
+                pipelineStartTime,
+                pipelineEndTime,
+                qaCompleteTime,
+                qaStartTime,
+                realityCaptureUploadedOn,
+                organizationName,
+                projectName,
+                floor,
+                scanDatasetId,
+                scanDatasetName,
+                pipelineStatus,
+                squareFootage,
+                realityCaptureName,
+                realityCaptureType
+              }: ApiScanDatasetStatsArgument = {})
+  {
+    addInstantGetterAndSetterToApiModel(this, "pipelineStartTime", pipelineStartTime);
+    addInstantGetterAndSetterToApiModel(this, "pipelineEndTime", pipelineEndTime);
+    addInstantGetterAndSetterToApiModel(this, "qaCompleteTime", qaCompleteTime);
+    addInstantGetterAndSetterToApiModel(this, "qaStartTime", qaStartTime);
+    addInstantGetterAndSetterToApiModel(this, "realityCaptureUploadedOn", realityCaptureUploadedOn);
+    this.organizationName = organizationName;
+    this.projectName = projectName;
+    this.floor = floor;
+    this.scanDatasetId = scanDatasetId;
+    this.scanDatasetName = scanDatasetName;
+    this.pipelineStatus = pipelineStatus;
+    this.squareFootage = squareFootage;
 
-   realityCaptureName?: string;
-   realityCaptureType?: string;
-   realityCaptureUploadedOn?: Date;
+    this.realityCaptureName = realityCaptureName;
+    this.realityCaptureType = realityCaptureType;
+  }
 
-   constructor(props: ApiScanDatasetStatsProps) {
-      addInstantGetterAndSetterToApiModel(this, 'pipelineStartTime', props.pipelineStartTime);
-      addInstantGetterAndSetterToApiModel(this, 'pipelineEndTime', props.pipelineEndTime);
-      addInstantGetterAndSetterToApiModel(this, 'qaCompleteTime', props.qaCompleteTime);
-      addInstantGetterAndSetterToApiModel(this, 'qaStartTime', props.qaStartTime);
-      addInstantGetterAndSetterToApiModel(this, 'realityCaptureUploadedOn', props.realityCaptureUploadedOn);
-      this.organizationName = props.organizationName;
-      this.projectName = props.projectName;
-      this.scanDatasetId = props.scanDatasetId;
-      this.scanDatasetName = props.scanDatasetName;
-      this.pipelineStatus = props.pipelineStatus;
-      this.squareFootage = props.squareFootage;
+  organizationName: string;
+  scanDatasetId: number;
+  projectName: string;
+  floor: string;
+  scanDatasetName: string;
+  pipelineStartTime: number;
+  pipelineEndTime: number;
+  pipelineStatus: string;
+  qaCompleteTime: number;
+  qaStartTime: number;
+  squareFootage: number;
 
-      this.realityCaptureName = props.realityCaptureName;
-      this.realityCaptureType = props.realityCaptureType;
-   }
-}
-
-
-type ApiScanDatasetStatsProps = {
-   organizationName: string;
-   scanDatasetId: number;
-   projectName: string;
-   floor: string;
-   scanDatasetName: string;
-   pipelineStartTime: number;
-   pipelineEndTime: number;
-   pipelineStatus: string;
-   qaCompleteTime: number;
-   qaStartTime: number;
-   squareFootage: number;
-
-   realityCaptureName?: string;
-   realityCaptureType?: string;
-   realityCaptureUploadedOn?: number;
+  realityCaptureName?: string;
+  realityCaptureType?: string;
+  realityCaptureUploadedOn?: number;
 }

--- a/source/models/api/api_scanned_element.ts
+++ b/source/models/api/api_scanned_element.ts
@@ -1,8 +1,12 @@
-import {ApiBuiltStatus} from "../enums";
-import {ApiElementDeviation} from "./api_element_deviation";
+import { ApiBuiltStatus } from "../enums";
 
+import type ApiElementDeviation from "./api_element_deviation";
+
+/**
+ * @deprecated This information is now all part of the {@link ApiPlannedElement}
+ */
 export class ApiScannedElement<Label extends ApiBuiltStatus> {
-  constructor({globalId, scanLabel, deviation, detectedInScan}: Partial<ApiScannedElement<Label>> = {}) {
+  constructor({ globalId, scanLabel, deviation, detectedInScan }: Partial<ApiScannedElement<Label>> = {}) {
     this.globalId = globalId;
     this.scanLabel = scanLabel;
     this.deviation = deviation;

--- a/source/models/api/api_team_member.ts
+++ b/source/models/api/api_team_member.ts
@@ -1,12 +1,12 @@
-import { ApiProjectWorkPackage } from "./api_project_work_package";
+import type ApiProjectWorkPackage from "./api_project_work_package";
 
 export class ApiTeamMember {
-  id?: number
-  name: string
-  userOrganization: string
-  email: string
-  role: string
-  masterformats?: string[]
+  id?: number;
+  name: string;
+  userOrganization: string;
+  email: string;
+  role: string;
+  masterformats?: string[];
   vendor?: ApiProjectWorkPackage;
 
   constructor({ id, name, userOrganization, email, role, masterformats, vendor }: Partial<ApiTeamMember> = {}) {
@@ -19,3 +19,5 @@ export class ApiTeamMember {
     this.vendor = vendor;
   }
 }
+
+export default ApiTeamMember;

--- a/source/models/api/api_user.ts
+++ b/source/models/api/api_user.ts
@@ -1,21 +1,21 @@
-import UserRole from "../enums/user_role";
+import type UserRole from "../enums/user_role";
 
 export class ApiUser {
-    name: string
-    userOrganization: string
-    email: string
-    role: UserRole
-    projectId: string
-    userId: number
+  name: string;
+  userOrganization: string;
+  email: string;
+  role: UserRole;
+  projectId: string;
+  userId: number;
 
-    constructor({name, userOrganization, email, role, projectId, userId}: Partial<ApiUser> = {}) {
-        this.name = name;
-        this.userOrganization = userOrganization;
-        this.email = email;
-        this.role = role;
-        this.projectId = projectId;
-        this.userId = userId
-    }
+  constructor({ name, userOrganization, email, role, projectId, userId }: Partial<ApiUser> = {}) {
+    this.name = name;
+    this.userOrganization = userOrganization;
+    this.email = email;
+    this.role = role;
+    this.projectId = projectId;
+    this.userId = userId;
+  }
 }
 
 export default ApiUser;

--- a/source/models/api/api_user_action.ts
+++ b/source/models/api/api_user_action.ts
@@ -1,15 +1,17 @@
-import {ApiActionPayload} from "./api_action_payload";
-import UserActionType from "../enums/user_action_type";
-import ApiUser from "./api_user";
-import {DateLike} from "./type_aliases";
 import addInstantGetterAndSetterToApiModel from "../../mixins/add_instant_getter_and_setter_to_api_model";
+
+import type ApiActionPayload from "./api_action_payload";
+import type ApiUser from "./api_user";
+import type UserActionType from "../enums/user_action_type";
+import type { DateLike } from "type_aliases";
 
 export class ApiUserAction {
   constructor(user: ApiUser,
               userEmail: string,
               type: UserActionType,
               createdAt: DateLike,
-              payload: ApiActionPayload[]) {
+              payload: ApiActionPayload[])
+  {
     this.user = user;
     this.userEmail = userEmail;
     this.type = type;

--- a/source/models/api/api_user_for_organization.ts
+++ b/source/models/api/api_user_for_organization.ts
@@ -1,32 +1,53 @@
-import UserRole from "../enums/user_role";
-import {DateLike} from "./type_aliases";
+import { addInstantGetterAndSetterToApiModel } from "../../mixins";
+
+import type UserRole from "../enums/user_role";
+import type { DateLike, ModifyPartial } from "type_aliases";
+
+export type ApiUserForOrganizationArgument = ModifyPartial<ApiUserForOrganization, {
+  latestInvitationExpiry: DateLike
+  accountCreationTime: DateLike
+  accountAcceptedTime: DateLike
+}>
 
 export class ApiUserForOrganization {
-    id: number
-    name: string
-    email: string
-    role: UserRole
-    projects: string[]
-    accessType: string
-    inviteStatus: string
-    masterformatCodes: string[]
-    latestInvitationExpiry: DateLike
-    accountCreationTime: DateLike
-    accountAcceptedTime: DateLike
+  id: number;
+  name: string;
+  email: string;
+  role: UserRole;
+  projects: string[];
+  accessType: string;
+  inviteStatus: string;
+  masterformatCodes: string[];
+  latestInvitationExpiry: number;
+  accountCreationTime: number;
+  accountAcceptedTime: number;
 
-    constructor({id, name,  email, role, projects, accessType, inviteStatus, masterformatCodes, latestInvitationExpiry, accountCreationTime, accountAcceptedTime}: Partial<ApiUserForOrganization> = {}) {
-        this.id = id;
-        this.name = name;
-        this.email = email;
-        this.role = role;
-        this.projects = projects;
-        this.accessType = accessType;
-        this.inviteStatus = inviteStatus;
-        this.masterformatCodes = masterformatCodes;
-        this.latestInvitationExpiry = latestInvitationExpiry;
-        this.accountCreationTime = accountCreationTime;
-        this.accountAcceptedTime = accountAcceptedTime;
-    }
+  constructor({
+                id,
+                name,
+                email,
+                role,
+                projects,
+                accessType,
+                inviteStatus,
+                masterformatCodes,
+                latestInvitationExpiry,
+                accountCreationTime,
+                accountAcceptedTime
+              }: ApiUserForOrganizationArgument = {})
+  {
+    this.id = id;
+    this.name = name;
+    this.email = email;
+    this.role = role;
+    this.projects = projects;
+    this.accessType = accessType;
+    this.inviteStatus = inviteStatus;
+    this.masterformatCodes = masterformatCodes;
+    addInstantGetterAndSetterToApiModel(this, "latestInvitationExpiry", latestInvitationExpiry);
+    addInstantGetterAndSetterToApiModel(this, "accountCreationTime", accountCreationTime);
+    addInstantGetterAndSetterToApiModel(this, "accountAcceptedTime", accountAcceptedTime);
+  }
 }
 
 export default ApiUserForOrganization;

--- a/source/models/api/api_user_permission.ts
+++ b/source/models/api/api_user_permission.ts
@@ -1,17 +1,17 @@
-import {UserPermissionType} from "../enums/user_permission_type";
-import {UserPermissionAction} from "../enums/user_permission_action"
+import type UserPermissionAction from "../enums/user_permission_action";
+import type UserPermissionType from "../enums/user_permission_type";
 
 export class ApiUserPermission {
-  id: number
-  userId: number
-  projectFirebaseId: string
-  organizationFirebaseId: string
-  masterformatCode: string
-  permissionType: UserPermissionType
-  permissionAction: UserPermissionAction
-  organizationName: string
-  projectName: string
-  workPackageId: number
+  id: number;
+  userId: number;
+  projectFirebaseId: string;
+  organizationFirebaseId: string;
+  masterformatCode: string;
+  permissionType: UserPermissionType;
+  permissionAction: UserPermissionAction;
+  organizationName: string;
+  projectName: string;
+  workPackageId: number;
 
   constructor({
                 id,
@@ -24,7 +24,8 @@ export class ApiUserPermission {
                 organizationName,
                 projectName,
                 workPackageId
-  }: Partial<ApiUserPermission>) {
+              }: Partial<ApiUserPermission>)
+  {
     this.id = id;
     this.userId = userId;
     this.projectFirebaseId = projectFirebaseId;

--- a/source/models/api/api_view.ts
+++ b/source/models/api/api_view.ts
@@ -1,13 +1,16 @@
-import {Vector3} from "three";
-import {DateLike, ModifyPartial, Vector3Like} from "./type_aliases";
+import { Vector3 } from "three";
+
 import addDateGetterAndSetterToDomainModel from "../../mixins/add_date_getter_and_setter_to_domain_model";
-import {UniformatId} from "uniformat";
-import {ApiInspectionModes} from "../enums";
-import SystemOfMeasurement from "../enums/system_of_measurement";
+import addReadOnlyPropertiesToModel from "../../mixins/add_read_only_properties_to_model";
+
+import type SystemOfMeasurement from "../enums/system_of_measurement";
+import type { ApiInspectionModes } from "../enums";
+import type { DateLike, ModifyPartial, Vector3Like } from "./type_aliases";
+import type { UniformatId } from "uniformat";
 
 export class PhotoViewerDetails {
   constructor(photoViewerDetails: Partial<PhotoViewerDetails> = {}) {
-    const {photoSessionId, photoLocationId, photoSessionIds} = photoViewerDetails;
+    const { photoSessionId, photoLocationId, photoSessionIds } = photoViewerDetails;
     this.photoSessionId = photoSessionId;
     this.photoLocationId = photoLocationId;
     this.photoSessionIds = photoSessionIds || [];
@@ -20,29 +23,29 @@ export class PhotoViewerDetails {
 
 export class DeviationTolerance {
   constructor(tolerance: Partial<DeviationTolerance> = {}) {
-    const {value, systemOfMeasurement} = tolerance;
+    const { value, systemOfMeasurement } = tolerance;
     this.value = value;
     this.systemOfMeasurement = systemOfMeasurement;
   }
 
   value: number;
-  systemOfMeasurement: SystemOfMeasurement
+  systemOfMeasurement: SystemOfMeasurement;
 }
 
 export class ViewTrades {
   constructor(trades: Partial<ViewTrades> = {}) {
-    const {shownUniformatCodes} = trades;
+    const { shownUniformatCodes } = trades;
     this.shownUniformatCodes = shownUniformatCodes;
   }
 
   shownUniformatCodes: UniformatId[];
 }
 
-export type ViewCameraParameter = ModifyPartial<ViewCamera, { position: Vector3Like, target: Vector3Like }>
+export type ViewCameraArgument = ModifyPartial<ViewCamera, { position: Vector3Like, target: Vector3Like }>
 
 export class ViewCamera {
-  constructor(camera: ViewCameraParameter = {}) {
-    const {position, target} = camera;
+  constructor(camera: ViewCameraArgument = {}) {
+    const { position, target } = camera;
     this.position = new Vector3(position?.x, position?.y, position?.z);
     this.target = new Vector3(target?.x, target?.y, target?.z);
   }
@@ -51,9 +54,14 @@ export class ViewCamera {
   target: Vector3;
 }
 
+export type ViewFiltersArgument = ModifyPartial<ViewFilters, {
+  trades: Partial<ViewTrades>,
+  deviationTolerance: Partial<DeviationTolerance>
+}>
+
 export class ViewFilters {
-  constructor(filters: Partial<ViewFilters> = {}) {
-    const {trades, deviationTolerance, pointCloudVisible, sectionPointCloud} = filters;
+  constructor(filters: ViewFiltersArgument = {}) {
+    const { trades, deviationTolerance, pointCloudVisible, sectionPointCloud } = filters;
     this.trades = new ViewTrades(trades);
     this.deviationTolerance = new DeviationTolerance(deviationTolerance);
     this.pointCloudVisible = pointCloudVisible;
@@ -67,16 +75,20 @@ export class ViewFilters {
 }
 
 export type SelectedElements = string[]
-export type ViewAttributesParameter = ModifyPartial<ViewAttributes, { camera: ViewCameraParameter }>
+export type ViewAttributesArgument = ModifyPartial<ViewAttributes, {
+  camera: ViewCameraArgument
+  filters: ViewFiltersArgument
+  photoViewerDetails: Partial<PhotoViewerDetails>
+}>
 
 export class ViewAttributes {
-  constructor(attributes: ViewAttributesParameter = {}) {
-    const {camera, filters, selectedElements, inspectionMode, photoViewerDetails} = attributes;
+  constructor(attributes: ViewAttributesArgument = {}) {
+    const { camera, filters, selectedElements, inspectionMode, photoViewerDetails } = attributes;
     this.camera = new ViewCamera(camera);
     this.filters = new ViewFilters(filters);
-    this.selectedElements = selectedElements;
+    this.selectedElements = selectedElements || [];
     this.inspectionMode = inspectionMode;
-    this.photoViewerDetails = photoViewerDetails;
+    this.photoViewerDetails = new PhotoViewerDetails(photoViewerDetails);
   }
 
   camera: ViewCamera;
@@ -86,7 +98,10 @@ export class ViewAttributes {
   photoViewerDetails: PhotoViewerDetails;
 }
 
-export type ViewParameter = ModifyPartial<ApiView, { viewAttributes: ViewAttributesParameter, createdAt: DateLike }>
+export type ApiViewArgument = ModifyPartial<ApiView, {
+  viewAttributes: ViewAttributesArgument,
+  createdAt: DateLike
+}>
 
 export class ApiView {
   constructor({
@@ -98,23 +113,20 @@ export class ApiView {
                 createdBy,
                 createdAt,
                 commentThreadIds
-              }: ViewParameter) {
+              }: ApiViewArgument)
+  {
+    addReadOnlyPropertiesToModel(this, { id, firebaseProjectId, firebaseFloorId, firebaseScanDatasetId, createdBy });
     addDateGetterAndSetterToDomainModel(this, "createdAt", createdAt);
-    this.id = id;
-    this.firebaseProjectId = firebaseProjectId;
-    this.firebaseFloorId = firebaseFloorId;
-    this.firebaseScanDatasetId = firebaseScanDatasetId;
     this.viewAttributes = new ViewAttributes(viewAttributes);
-    this.createdBy = createdBy;
     this.commentThreadIds = commentThreadIds;
   }
 
-  id: number;
-  firebaseProjectId: string;
-  firebaseFloorId: string;
-  firebaseScanDatasetId: string;
+  readonly id: number;
+  readonly firebaseProjectId: string;
+  readonly firebaseFloorId: string;
+  readonly firebaseScanDatasetId: string;
   viewAttributes: ViewAttributes;
-  createdBy: string;
+  readonly createdBy: string;
   createdAt: Date;
   commentThreadIds: number[];
 }

--- a/source/models/api/api_work_package.ts
+++ b/source/models/api/api_work_package.ts
@@ -1,7 +1,8 @@
 import { addReadOnlyPropertiesToModel } from "../../mixins";
-import { ProjectWorkPackageType } from "../enums";
 
-export default class ApiWorkPackage {
+import type { ProjectWorkPackageType } from "../enums";
+
+export class ApiWorkPackage {
   constructor({ id, name, firebaseProjectId, type }: Partial<ApiWorkPackage> = {}) {
     addReadOnlyPropertiesToModel(this, { id, firebaseProjectId, type });
     this.name = name;
@@ -10,5 +11,7 @@ export default class ApiWorkPackage {
   readonly id: number;
   name: string;
   readonly firebaseProjectId: string;
-  readonly type: ProjectWorkPackageType
+  readonly type: ProjectWorkPackageType;
 }
+
+export default ApiWorkPackage;

--- a/source/models/api/deprecated_api_pipeline.ts
+++ b/source/models/api/deprecated_api_pipeline.ts
@@ -1,3 +1,6 @@
+/**
+ * @deprecated use {@link ApiPipeline} instead
+ */
 export class DeprecatedApiPipeline {
   workflowName: string;
   startTime: number;

--- a/source/models/api/index.ts
+++ b/source/models/api/index.ts
@@ -1,126 +1,68 @@
-export { ArgoMetadata, ApiArgoResponse } from "./api_argo_response";
+export * from "./api_action_payload";
+export { ApiArgoResponse, ArgoMetadata } from "./api_argo_response";
+export { ApiBcfBuildingElement, ApiBcfBuildingElementArgument } from "./api_bcf_building_element";
+export { ApiBcfIssue, ApiBcfIssueArgument } from "./api_bcf_issue";
+export { ApiClassificationCode } from "./api_classification_code";
+export * from "./api_cloud_file";
 export { ApiComment } from "./api_comment";
 export { ApiCommentThread } from "./api_comment_thread";
-export { AvvirApiFiles, AvvirApiFileIds, ApiCloudFileArgument, ApiCloudFile } from "./api_cloud_file";
-export { ApiConstructionGrid } from "./api_construction_grid";
+export * from "./api_construction_grid";
 export { ApiCreateInvitationForm } from "./api_create_invitation_form";
-export { ApiDetailedElement } from "./api_detailed_element";
-export { ApiElementDeviation } from "./api_element_deviation";
-export { ApiFloor, ApiFloorArgument } from "./api_floor";
-export { ApiGridLine } from "./api_grid_line";
-export { ApiInvitation } from "./api_invitation";
-export { ApiInspectReport } from "./api_inspect_report";
-export { ApiInspectReportEntry } from "./api_inspect_report_entry";
-export { ApiInspectReportEntryElement } from "./api_inspect_report_entry_element";
-export { ApiMasterformat } from "./api_masterformat";
-export { ApiMatrix3 } from "./api_matrix_3";
-export { ApiMatrix4 } from "./api_matrix_4";
-export { ApiOrganization } from "./api_organization";
-export { ApiPhotoArea } from "./api_photo_area";
-export { ApiPhotoLocation, ApiPhotoLocationArgs } from "./api_photo_location";
-export { ApiPhotoLocationProperties, ApiPhotoLocation3d, ApiPhotoLocation3dArguments } from "./api_photo_location_3d";
-export { ApiPhotoSessionArgs, ApiPhotoSession } from "./api_photo_session";
-export { ApiPipeline, ApiPipelineArgument } from "./api_pipeline";
-export { ApiPlannedElement } from "./api_planned_element";
-export { ApiProject, ApiProjectArgument } from "./api_project";
-export { ApiProjectReport } from "./api_project_report";
-export { ApiProjectSettings } from "./api_project_settings";
-export {
-  ApiProjectCostAnalysisProgressArgument, ApiProjectCostAnalysisProgress
-} from "./api_project_cost_analysis_progress";
-export { ApiProjectMasterformatProgress } from "./api_project_masterformat_progress";
-export { ApiProjectReportVersion } from "./api_project_report_version";
-export { ApiProjectAreaWorkPackage } from "./api_project_area_work_package";
-export { ApiProjectArea } from "./api_project_area";
-export { ApiProjectSummary, ApiProjectAreaProgress } from "./api_project_summary";
-export { ApiProjectWorkPackage } from "./api_project_work_package";
-export { ApiProjectListing } from "./api_project_listing";
-export { ApiClassificationCode } from "./api_classification_code";
-export { ApiRecipe, ApiRecipeStep, ApiRecipeArgument, ApiRecipeStepArgument } from "./api_recipe";
+export * from "./api_detailed_element";
+export * from "./api_element_deviation";
+export * from "./api_floor";
+export * from "./api_purpose_type";
+export * from "./api_grid_line";
+export { ApiGroup, ApiGroupMember } from "./api_groups";
+export * from "./api_inspect_report";
+export * from "./api_inspect_report_entry";
+export * from "./api_inspect_report_entry_element";
+export { ApiIntegrationCredentials, ApiIntegrationCredentialsArgument } from "./api_integration_credentials";
+export { ApiIntegrationProject, ApiIntegrationProjectArgument } from "./api_integration_project";
+export * from "./api_invitation";
+export * from "./api_masterformat";
+export { ApiMasterformatProgress, ApiMasterformatProgressArgument } from "./api_masterformat_progress";
+export * from "./api_matrix_3";
+export * from "./api_matrix_4";
+export * from "./api_organization";
+export * from "./api_photo_area";
+export { ApiPhotoLocation3d, ApiPhotoLocation3dArgument, ApiPhotoLocationProperties } from "./api_photo_location_3d";
+export * from "./api_photo_location";
+export * from "./api_photo_session";
+export * from "./api_pipeline";
+export * from "./api_planned_element";
+export * from "./api_progress_category";
+export * from "./api_progress_scan_dataset";
+export * from "./api_project";
+export * from "./api_project_area";
+export * from "./api_project_summary";
+export * from "./api_project_area_work_package";
+export { ApiProjectCostAnalysisProgress, ApiProjectCostAnalysisProgressArgument } from "./api_project_cost_analysis_progress";
 export { ApiProjectCostAnalysisProgressValidationResult } from "./api_project_cost_anaylsis_progress_validation_result";
-export { ApiProjectWorkPackageCost } from "./api_project_work_package_cost";
-export {
-  ApiPhotoAreaPurposeType,
-  ApiScanDatasetPurposeType,
-  ApiFloorPurposeType,
-  ApiPurposeType,
-  ApiProjectPurposeType,
-  ApiScanDatasetTypeKeys,
-  ApiPurposeTypeKeys,
-  ApiFloorTypeKeys,
-  ApiProjectTypeKeys,
-  ApiPhotoAreaTypeKeys,
-  ApiFloorTypeMap,
-  ApiPhotoAreaTypeMap,
-  ApiProjectTypeMap,
-  ApiScanDatasetTypeMap,
-  isApiPurposeType,
-  isApiFloorPurposeType,
-  isApiPhotoAreaPurposeType,
-  isApiScanDatasetPurposeType
-} from "./api_purpose_type";
-
-export { ApiRunningProcess, ApiRunningProcessArgs } from "./api_running_process";
-export { ApiScanDataset, ApiScanDatasetArgument, ApiScanDatasetQaState } from "./api_scan_dataset";
-
-export {
-  ApiScannedElement,
-  isDeviationScanResult,
-  ApiScannedElementTypeMap,
-  ApiScannedElementType,
-  DeviationScanResult,
-  InPlaceScanResult,
-  NotBuiltScanResult
-} from "./api_scanned_element";
-
-export { ApiUser } from "./api_user";
-export { DeprecatedApiPipeline } from "./deprecated_api_pipeline";
-export { ApiProgressCategory } from "./api_progress_category";
-export { ApiProgressScanDataset } from "./api_progress_scan_dataset";
-
-export {
-  PhotoViewerDetails,
-  ViewCamera,
-  ApiView,
-  ViewAttributes,
-  ViewParameter,
-  ViewCameraParameter,
-  ViewFilters,
-  ViewTrades,
-  DeviationTolerance,
-  ViewAttributesParameter,
-  SelectedElements
-} from "./api_view";
-
-export { ApiQueryResource } from "./api_query_resource";
-export { ApiUserAction } from "./api_user_action";
-export { ApiActionPayload, ApiBehavioralData } from "./api_action_payload";
-export { ApiIntegrationCredentials, ApiIntegrationCredentialsArgs } from "./api_integration_credentials";
-export { ApiIntegrationProject, ApiIntegrationProjectArgs } from "./api_integration_project";
-export { ApiTeamMember } from "./api_team_member";
-
-export {
-  AssociationIds,
-  DateLike,
-  Matrix3Like,
-  Matrix4Like,
-  FileLike,
-  Vector2Like,
-  Vector3Like,
-  Vector4Like,
-  Modify,
-  ModifyPartial,
-  DeepPartial
-} from "./type_aliases";
-
-export { ApiQuaternion, isApiQuaternion } from "./api_quaternion";
-export { ApiBcfIssue, ApiBcfIssueArgs } from "./api_bcf_issue";
-export { ApiBcfBuildingElementArgs, ApiBcfBuildingElement } from "./api_bcf_building_element";
-export { ApiUserPermission } from "./api_user_permission";
-export { ApiUserForOrganization } from "./api_user_for_organization";
-export { ApiRpcSession } from "./api_rpc_session";
+export { ApiProjectListing } from "./api_project_listing";
+export { ApiProjectMasterformatProgress } from "./api_project_masterformat_progress";
+export * from "./api_project_report";
+export * from "./api_project_report_version";
+export * from "./api_project_settings";
+export * from "./api_project_work_package";
+export * from "./api_project_work_package_cost";
+export * from "./api_quaternion";
+export * from "./api_query_resource";
+export * from "./api_recipe";
 export { ApiRpcQueryRequest } from "./api_rpc_query_request";
 export { ApiRpcQueryResponse } from "./api_rpc_query_response";
-export { ApiScanDatasetStats } from "./api_scandataset_stats";
-export { ApiGroup, ApiGroupMember } from "./api_groups";
-export { ApiMasterformatProgressArgs, ApiMasterformatProgress } from "./api_masterformat_progress";
+export { ApiRpcSession } from "./api_rpc_session";
+export * from "./api_running_process";
+export * from "./api_scan_dataset";
+export * from "./api_scandataset_stats";
+export * from "./api_scanned_element";
+export * from "./api_team_member";
+export * from "./api_user";
+export * from "./api_user_action";
+export * from "./api_user_for_organization";
+export * from "./api_user_permission";
+export * from "./api_view";
+export * from "./api_work_package";
+export * from "./type_aliases";
+export * from "./deprecated_api_pipeline";
+export * from "./trade";

--- a/source/models/api/trade/api_captured_trade_cost.ts
+++ b/source/models/api/trade/api_captured_trade_cost.ts
@@ -1,4 +1,4 @@
-export default class ApiCapturedTradeCost {
+export class ApiCapturedTradeCost {
   constructor({ tradeCode, capturedQuantity, modeledQuantity }: Partial<ApiCapturedTradeCost> = {}) {
     this.tradeCode = tradeCode;
     this.capturedQuantity = capturedQuantity;
@@ -9,3 +9,5 @@ export default class ApiCapturedTradeCost {
   capturedQuantity: number;
   modeledQuantity: number;
 }
+
+export default ApiCapturedTradeCost;

--- a/source/models/api/trade/api_planned_trade_cost.ts
+++ b/source/models/api/trade/api_planned_trade_cost.ts
@@ -1,4 +1,4 @@
-export default class ApiPlannedTradeCost {
+export class ApiPlannedTradeCost {
   constructor({
                 tradeCode,
                 unitOfMeasure,
@@ -19,3 +19,5 @@ export default class ApiPlannedTradeCost {
   plannedTotalCost: number;
   plannedQuantity: number;
 }
+
+export default ApiPlannedTradeCost;

--- a/source/models/api/trade/api_trade.ts
+++ b/source/models/api/trade/api_trade.ts
@@ -1,4 +1,4 @@
-export default class ApiTrade {
+export class ApiTrade {
   constructor({ code, parentCode, title, workPackageId, childCodes }: Partial<ApiTrade> = {}) {
     this.code = code;
     if (parentCode) {
@@ -15,3 +15,5 @@ export default class ApiTrade {
   workPackageId: number;
   childCodes: string[];
 }
+
+export default ApiTrade;

--- a/source/models/api/trade/api_trade_cost.ts
+++ b/source/models/api/trade/api_trade_cost.ts
@@ -1,4 +1,4 @@
-export default class ApiTradeCost {
+export class ApiTradeCost {
   constructor({ tradeCode, unitOfMeasure, plannedUnitCost, plannedTotalCost, plannedQuantity, capturedQuantity, modeledQuantity, reportedQuantity }: Partial<ApiTradeCost> = {}) {
     this.tradeCode = tradeCode;
     this.unitOfMeasure = unitOfMeasure;
@@ -20,3 +20,5 @@ export default class ApiTradeCost {
   modeledQuantity: number;
   reportedQuantity: number;
 }
+
+export default ApiTradeCost;

--- a/source/models/api/trade/index.ts
+++ b/source/models/api/trade/index.ts
@@ -1,0 +1,4 @@
+export { ApiCapturedTradeCost } from "./api_captured_trade_cost";
+export { ApiPlannedTradeCost } from "./api_planned_trade_cost";
+export { ApiTrade } from "./api_trade";
+export { ApiTradeCost } from "./api_trade_cost";

--- a/source/models/enums/api_floor_file_deletion_mode.ts
+++ b/source/models/enums/api_floor_file_deletion_mode.ts
@@ -1,0 +1,9 @@
+export enum ApiFloorFileDeletionMode {
+  ALL_FILES = "ALL_FILES",
+  FLOOR_ONLY = "FLOOR_ONLY"
+}
+
+export const ALL_FILES = ApiFloorFileDeletionMode.ALL_FILES;
+export const FLOOR_ONLY = ApiFloorFileDeletionMode.FLOOR_ONLY;
+
+export default ApiFloorFileDeletionMode;

--- a/source/models/enums/index.ts
+++ b/source/models/enums/index.ts
@@ -1,24 +1,25 @@
+export * from "./api_built_status";
+export * from "./api_floor_file_deletion_mode";
+export * from "./api_integration_credentials_type";
+export * from "./association_type";
 export * from "./deviation_status";
-export * from "./inspection_modes";
 export * from "./event_type";
+export * from "./inspection_modes";
 export * from "./notification_level";
 export * from "./photo_projection_type";
 export * from "./photo_rotation_type";
 export * from "./pipeline_types";
 export * from "./process_status";
+export * from "./progress_type";
+export * from "./project_work_package_type";
 export * from "./running_process_status";
-export * from "./api_built_status";
 export * from "./system_of_measurement";
 export * from "./uploader_status";
-export * from "./user_auth_type";
-export * from "./user_role";
 export * from "./user_action_type";
-export * from "./api_integration_credentials_type";
+export * from "./user_auth_type";
 export * from "./user_permission_action";
 export * from "./user_permission_type";
-export * from "./association_type";
-export * from "./project_work_package_type";
-export * from "./progress_type";
+export * from "./user_role";
 
 export {
   ProjectPurposeType,

--- a/tests/api/floor_api_test.ts
+++ b/tests/api/floor_api_test.ts
@@ -1,488 +1,519 @@
-import {sandbox} from "../test_utils/setup_tests";
-import {expect} from "chai";
+import { sandbox } from "../test_utils/setup_tests";
+import { expect } from "chai";
 import fetchMock from "fetch-mock";
 import _ from "underscore";
 
-import ApiFloor from "../../source/models/api/api_floor";
+import ApiFloorFileDeletionMode from "../../source/models/enums/api_floor_file_deletion_mode";
 import Config from "../../source/config";
 import FloorApi from "../../source/api/floor_api";
 import Http from "../../source/utilities/http";
-import {FIREBASE} from "../../source/models/enums/user_auth_type";
-import {User} from "../../source/utilities/get_authorization_headers";
-import {ApiMasterformat, ApiMasterformatProgress, ApiPlannedElement, ProgressType} from "../../source";
-import {ApiFloorFileDeletionMode} from "../../source/models/api/ApiFloorFileDeletionMode";
+import { ApiFloor, ApiMasterformat, ApiMasterformatProgress, ApiPlannedElement, FIREBASE, ProgressType, User } from "../../source";
 
 describe("FloorApi", () => {
-    let user;
+  let user;
+  beforeEach(() => {
+    user = {
+      authType: FIREBASE,
+      firebaseUser: { idToken: "some-firebase.id.token" }
+    };
+  });
+
+  describe("#listFloorsForProject", () => {
     beforeEach(() => {
-        user = {
-            authType: FIREBASE,
-            firebaseUser: {idToken: "some-firebase.id.token"}
-        };
+      fetchMock.get(`${Http.baseUrl()}/projects/some-project-id/floors`, 200);
     });
 
-    describe("#listFloorsForProject", () => {
-        beforeEach(() => {
-            fetchMock.get(`${Http.baseUrl()}/projects/some-project-id/floors`, 200);
-        });
+    it("makes a request to the gateway", () => {
+      FloorApi.listFloorsForProject("some-project-id", {
+        firebaseUser: {
+          idToken: "some-firebase.id.token"
+        }
+      } as User);
 
-        it("makes a request to the gateway", () => {
-            FloorApi.listFloorsForProject("some-project-id", {
-                firebaseUser: {
-                    idToken: "some-firebase.id.token"
-                }
-            } as User);
-
-            expect(fetchMock.lastCall()[0]).to.eq(`${Http.baseUrl()}/projects/some-project-id/floors`);
-            expect(fetchMock.lastOptions().headers["Accept"]).to.eq("application/json");
-        });
-
-        it("includes the authorization headers", () => {
-            FloorApi.listFloorsForProject("some-project-id", user);
-
-            expect(fetchMock.lastOptions().headers.firebaseIdToken).to.eq("some-firebase.id.token");
-        });
+      expect(fetchMock.lastCall()[0]).to.eq(`${Http.baseUrl()}/projects/some-project-id/floors`);
+      expect(fetchMock.lastOptions().headers["Accept"]).to.eq("application/json");
     });
 
-    describe("#getFloor", () => {
-        beforeEach(() => {
-            fetchMock.get(`${Http.baseUrl()}/projects/some-project-id/floors/some-floor-id`, {
-                status: 200,
-                body: {
-                    id: "some-floor-id",
-                    floorNumber: "2",
-                    defaultFirebaseScanDatasetId: "some-scan-id",
-                    scanDatasets: [{
-                        scanDatasetId: "some-scan-id",
-                        scanNumber: 1,
-                        scanDate: 12345,
-                    }]
-                }
-            });
-        });
+    it("includes the authorization headers", () => {
+      FloorApi.listFloorsForProject("some-project-id", user);
 
-        it("makes an authenticated call to the endpoint", () => {
-            FloorApi.getFloor({
-                projectId: "some-project-id",
-                floorId: "some-floor-id",
-            }, user);
-            const fetchCall = fetchMock.lastCall();
-            const lastFetchOpts = fetchMock.lastOptions();
+      expect(fetchMock.lastOptions().headers.firebaseIdToken).to.eq("some-firebase.id.token");
+    });
+  });
 
-            expect(fetchCall[0]).to.eq(`${Http.baseUrl()}/projects/some-project-id/floors/some-floor-id`);
-            expect(lastFetchOpts.headers).to.include.keys("firebaseIdToken");
-            expect(lastFetchOpts.headers.firebaseIdToken).to.eq("some-firebase.id.token");
-        });
+  describe("#getFloor", () => {
+    beforeEach(() => {
+      fetchMock.get(`${Http.baseUrl()}/projects/some-project-id/floors/some-floor-id`, {
+        status: 200,
+        body: {
+          id: "some-floor-id",
+          floorNumber: "2",
+          defaultFirebaseScanDatasetId: "some-scan-id",
+          scanDatasets: [{
+            scanDatasetId: "some-scan-id",
+            scanNumber: 1,
+            scanDate: 12345,
+          }]
+        }
+      });
     });
 
-    describe("#createFloor", () => {
-        beforeEach(() => {
-            fetchMock.post(`${Http.baseUrl()}/projects/some-project-id/floors`, {status: 200, body: {}});
-        });
+    it("makes an authenticated call to the endpoint", () => {
+      FloorApi.getFloor({
+        projectId: "some-project-id",
+        floorId: "some-floor-id",
+      }, user);
+      const fetchCall = fetchMock.lastCall();
+      const lastFetchOpts = fetchMock.lastOptions();
 
-        it("makes a call to the floor creation endpoint", () => {
-            FloorApi.createFloor("some-project-id", "14", {firebaseUser: {idToken: "some-firebase.id.token"}} as User);
-            const fetchCall = fetchMock.lastCall();
+      expect(fetchCall[0]).to.eq(`${Http.baseUrl()}/projects/some-project-id/floors/some-floor-id`);
+      expect(lastFetchOpts.headers).to.include.keys("firebaseIdToken");
+      expect(lastFetchOpts.headers.firebaseIdToken).to.eq("some-firebase.id.token");
+    });
+  });
 
-            expect(fetchCall[0]).to.eq(`${Http.baseUrl()}/projects/some-project-id/floors`);
-            expect(JSON.parse(fetchCall[1].body as string)).to.deep.eq({text: "14"});
-        });
-
-        it("sends the request with authorization headers", () => {
-            FloorApi.createFloor("some-project-id", "14", user);
-            const fetchCall = fetchMock.lastCall();
-            const lastFetchOpts = fetchMock.lastOptions();
-
-            expect(fetchCall[0]).to.eq(`${Http.baseUrl()}/projects/some-project-id/floors`);
-            expect(lastFetchOpts.headers).to.include.keys("firebaseIdToken");
-            expect(lastFetchOpts.headers.firebaseIdToken).to.eq("some-firebase.id.token");
-        });
-
-        describe("when the call fails", () => {
-            beforeEach(() => {
-                fetchMock.post(`${Http.baseUrl()}/projects/some-project-id/floors`,
-                    {
-                        status: 500, body: {some: "body", message: "some error message"},
-                        headers: {"ContentType": "application/json"}
-                    },
-                    {overwriteRoutes: true});
-            });
-
-            it("calls the shared error handler", () => {
-                sandbox.stub(Config, "sharedErrorHandler");
-                return FloorApi.createFloor("some-project-id",
-                    "14",
-                    {authType: FIREBASE, firebaseUser: {idToken: "some-firebase.id.token"}})
-                    .catch(_.noop)
-                    .finally(() => {
-                        expect(Config.sharedErrorHandler).to.have.been.calledWithMatch({
-                            action: "createFloor",
-                            error: {
-                                verboseMessage: "500 Internal Server Error: 'some error message' at `.../projects/some-project-id/floors`"
-                            }
-                        });
-                    });
-            });
-        });
+  describe("#createFloor", () => {
+    beforeEach(() => {
+      fetchMock.post(`${Http.baseUrl()}/projects/some-project-id/floors`, { status: 200, body: {} });
     });
 
-    describe("#updateFloor", () => {
-        beforeEach(() => {
-            fetchMock.patch(`${Http.baseUrl()}/projects/some-project-id/floors/some-floor-id`, 200);
-        });
+    it("makes a call to the floor creation endpoint", () => {
+      FloorApi.createFloor("some-project-id", "14", { firebaseUser: { idToken: "some-firebase.id.token" } } as User);
+      const fetchCall = fetchMock.lastCall();
 
-        it("makes a call to the correct endpoint", () => {
-            FloorApi.updateFloor({
-                projectId: "some-project-id",
-                floorId: "some-floor-id"
-            }, new ApiFloor({
-                defaultFirebaseScanDatasetId: "some-scan-id",
-                floorElevation: 10.0
-            }), {firebaseUser: {idToken: "some-firebase.id.token"}} as User);
-            const fetchCall = fetchMock.lastCall();
-            const lastFetchOpts = fetchMock.lastOptions();
-
-            expect(lastFetchOpts.headers).to.include.keys("Content-Type");
-            expect(lastFetchOpts.headers["Content-Type"]).to.eq("application/json");
-            expect(fetchCall[0]).to.eq(`${Http.baseUrl()}/projects/some-project-id/floors/some-floor-id`);
-            expect(fetchCall[1].body).to.deep.eq(JSON.stringify(new ApiFloor({
-                defaultFirebaseScanDatasetId: "some-scan-id",
-                floorElevation: 10.0
-            })));
-        });
-
-        it("sends the request with authorization headers", () => {
-            FloorApi.updateFloor({
-                projectId: "some-project-id",
-                floorId: "some-floor-id"
-            }, new ApiFloor({
-                defaultFirebaseScanDatasetId: "some-scan-id"
-            }), user);
-            const fetchCall = fetchMock.lastCall();
-            const lastFetchOpts = fetchMock.lastOptions();
-
-            expect(fetchCall[0]).to.eq(`${Http.baseUrl()}/projects/some-project-id/floors/some-floor-id`);
-            expect(lastFetchOpts.headers).to.include.keys("firebaseIdToken");
-            expect(lastFetchOpts.headers.firebaseIdToken).to.eq("some-firebase.id.token");
-        });
-
-        describe("when the call fails", () => {
-            beforeEach(() => {
-                fetchMock.patch(`${Http.baseUrl()}/projects/some-project-id/floors/some-floor-id`,
-                    {
-                        status: 500, body: {some: "body"},
-                        headers: {"ContentType": "application/json"}
-                    },
-                    {overwriteRoutes: true});
-            });
-
-            it("dispatches an api failure notification", () => {
-                sandbox.stub(Config, "sharedErrorHandler");
-                return FloorApi.updateFloor({
-                        projectId: "some-project-id",
-                        floorId: "some-floor-id"
-                    },
-                    new ApiFloor({
-                        defaultFirebaseScanDatasetId: "some-scan-id"
-                    }),
-                    {firebaseUser: {idToken: "some-firebase.id.token"}} as User)
-                    .catch(_.noop)
-                    .finally(() => {
-                        expect(Config.sharedErrorHandler).to.have.been.calledWithMatch({});
-                    });
-            });
-        });
+      expect(fetchCall[0]).to.eq(`${Http.baseUrl()}/projects/some-project-id/floors`);
+      expect(JSON.parse(fetchCall[1].body as string)).to.deep.eq({ text: "14" });
     });
 
-    describe("#reorderFloors", () => {
-        const requestBody = []
-        const associationIds = {projectId: "some-project-id"};
-        beforeEach(() => {
-            fetchMock.post(`${Http.baseUrl()}/projects/some-project-id/floors/reorder-floors`, {
-                status: 200,
-                body: requestBody
-            });
-        });
+    it("sends the request with authorization headers", () => {
+      FloorApi.createFloor("some-project-id", "14", user);
+      const fetchCall = fetchMock.lastCall();
+      const lastFetchOpts = fetchMock.lastOptions();
 
-        it("makes a call to the correct endpoint", () => {
-            FloorApi.reorderFloors(associationIds, requestBody, user);
-            const fetchCall = fetchMock.lastCall();
-            expect(fetchCall[0]).to.eq(`${Http.baseUrl()}/projects/some-project-id/floors/reorder-floors`);
-        });
-
-        it("sends the request with authorization headers", () => {
-            FloorApi.reorderFloors(associationIds, requestBody, user);
-            const lastFetchOpts = fetchMock.lastOptions();
-            expect(lastFetchOpts.headers).to.include.keys("firebaseIdToken");
-            expect(lastFetchOpts.headers.firebaseIdToken).to.eq("some-firebase.id.token");
-        });
+      expect(fetchCall[0]).to.eq(`${Http.baseUrl()}/projects/some-project-id/floors`);
+      expect(lastFetchOpts.headers).to.include.keys("firebaseIdToken");
+      expect(lastFetchOpts.headers.firebaseIdToken).to.eq("some-firebase.id.token");
     });
 
-    describe("#deleteFloor", () => {
-        beforeEach(() => {
-            fetchMock.delete(`${Http.baseUrl()}/projects/some-project-id/floors/some-floor-id`, 200);
-        });
+    describe("when the call fails", () => {
+      beforeEach(() => {
+        fetchMock.post(`${Http.baseUrl()}/projects/some-project-id/floors`,
+          {
+            status: 500, body: { some: "body", message: "some error message" },
+            headers: { "ContentType": "application/json" }
+          },
+          { overwriteRoutes: true });
+      });
 
-        it("makes a call to the correct endpoint", () => {
-            FloorApi.deleteFloor({
-                projectId: "some-project-id",
-                floorId: "some-floor-id",
-                deletionModeSelection: ""
-            }, {firebaseUser: {idToken: "some-firebase.id.token"}} as User);
-            const fetchCall = fetchMock.lastCall();
-            const lastFetchOpts = fetchMock.lastOptions();
-
-            expect(lastFetchOpts.headers).to.include.keys("Content-Type");
-            expect(lastFetchOpts.headers["Content-Type"]).to.eq("application/json");
-            expect(fetchCall[0]).to.eq(`${Http.baseUrl()}/projects/some-project-id/floors/some-floor-id`);
-        });
-
-        it("sends the request with authorization headers", () => {
-            FloorApi.deleteFloor({
-                projectId: "some-project-id",
-                floorId: "some-floor-id",
-                deletionModeSelection: ""
-            }, user);
-            const fetchCall = fetchMock.lastCall();
-            const lastFetchOpts = fetchMock.lastOptions();
-
-            expect(fetchCall[0]).to.eq(`${Http.baseUrl()}/projects/some-project-id/floors/some-floor-id`);
-            expect(lastFetchOpts.headers).to.include.key("firebaseIdToken");
-            expect(lastFetchOpts.headers.firebaseIdToken).to.eq("some-firebase.id.token");
-        });
-
-        describe("when the call fails", () => {
-            beforeEach(() => {
-                fetchMock.delete(`${Http.baseUrl()}/projects/some-project-id/floors/some-floor-id`,
-                    {
-                        status: 500, body: {some: "body"},
-                        headers: {"ContentType": "application/json"}
-                    },
-                    {overwriteRoutes: true});
+      it("calls the shared error handler", () => {
+        sandbox.stub(Config, "sharedErrorHandler");
+        return FloorApi.createFloor("some-project-id",
+            "14",
+            { authType: FIREBASE, firebaseUser: { idToken: "some-firebase.id.token" } })
+          .catch(_.noop)
+          .finally(() => {
+            expect(Config.sharedErrorHandler).to.have.been.calledWithMatch({
+              action: "createFloor",
+              error: {
+                verboseMessage: "500 Internal Server Error: 'some error message' at `.../projects/some-project-id/floors`"
+              }
             });
+          });
+      });
+    });
+  });
 
-            it("dispatches an api failure notification", () => {
-                sandbox.stub(Config, "sharedErrorHandler");
-                return FloorApi.deleteFloor({
-                        projectId: "some-project-id",
-                        floorId: "some-floor-id",
-                        deletionModeSelection: ""
-                    },
-                    {firebaseUser: {idToken: "some-firebase.id.token"}} as User)
-                    .catch(_.noop)
-                    .finally(() => {
-                        expect(Config.sharedErrorHandler).to.have.been.calledWithMatch({});
-                    });
-            });
-        });
-
-        describe("delete floors with deletion mode selection", () => {
-            beforeEach(() => {
-                fetchMock.delete(`${Http.baseUrl()}/projects/some-project-id/floors/some-floor-id?deletionModeSelection=${ApiFloorFileDeletionMode.ALL_FILES}`, 200);
-            });
-
-            it("delete floor with deletion mode ALL_FILES", () => {
-                return FloorApi.deleteFloor({
-                        projectId: "some-project-id",
-                        floorId: "some-floor-id",
-                        deletionModeSelection: "ALL_FILES"
-                    }, user);
-
-                const fetchCall = fetchMock.lastCall();
-                const lastFetchOpts = fetchMock.lastOptions();
-
-                expect(fetchCall[0]).to.eq(`${Http.baseUrl()}/projects/some-project-id/floors/some-floor-id?deletionModeSelection=${ApiFloorFileDeletionMode.ALL_FILES}`);
-                expect(lastFetchOpts.headers).to.include.key("firebaseIdToken");
-                expect(lastFetchOpts.headers.firebaseIdToken).to.eq("some-firebase.id.token");
-            });
-        });
+  describe("#updateFloor", () => {
+    beforeEach(() => {
+      fetchMock.patch(`${Http.baseUrl()}/projects/some-project-id/floors/some-floor-id`, 200);
     });
 
-    describe("#updatePlannedBuildingElements", () => {
-        beforeEach(() => {
-            fetchMock.patch(`${Http.baseUrl()}/projects/some-project-id/floors/some-floor-id/planned-building-elements?validate=false`, 200);
-            fetchMock.patch(`${Http.baseUrl()}/projects/some-project-id/floors/some-floor-id/planned-building-elements?validate=true`, 200);
-        });
+    it("makes a call to the correct endpoint", () => {
+      FloorApi.updateFloor({
+        projectId: "some-project-id",
+        floorId: "some-floor-id"
+      }, new ApiFloor({
+        defaultFirebaseScanDatasetId: "some-scan-id",
+        floorElevation: 10.0
+      }), { firebaseUser: { idToken: "some-firebase.id.token" } } as User);
+      const fetchCall = fetchMock.lastCall();
+      const lastFetchOpts = fetchMock.lastOptions();
 
-        it("makes a call to the endpoint", () => {
-            FloorApi.updatePlannedBuildingElements({
-                projectId: "some-project-id",
-                floorId: "some-floor-id"
-            }, [new ApiPlannedElement({
-                globalId: "some-global-id",
-                name: "some-name"
-            })], user);
-            const fetchCall = fetchMock.lastCall();
-            const lastFetchOpts = fetchMock.lastOptions();
-
-            expect(lastFetchOpts.headers).to.include.key("Content-Type");
-            expect(lastFetchOpts.headers["Content-Type"]).to.eq("application/json");
-            expect(fetchCall[0]).to.eq(`${Http.baseUrl()}/projects/some-project-id/floors/some-floor-id/planned-building-elements?validate=false`);
-            expect(fetchCall[1].body).to.deep.eq(JSON.stringify([new ApiPlannedElement({
-                    globalId: "some-global-id",
-                    name: "some-name"
-                })]
-            ));
-        });
-
-        it("sends the request with authorization headers", () => {
-            FloorApi.updatePlannedBuildingElements({
-                projectId: "some-project-id",
-                floorId: "some-floor-id"
-            }, [new ApiPlannedElement({
-                globalId: "some-global-id",
-                name: "some-name"
-            })], user);
-            const fetchCall = fetchMock.lastCall();
-            const lastFetchOpts = fetchMock.lastOptions();
-
-            expect(fetchCall[0]).to.eq(`${Http.baseUrl()}/projects/some-project-id/floors/some-floor-id/planned-building-elements?validate=false`);
-            expect(lastFetchOpts.headers).to.include.key("firebaseIdToken");
-            expect(lastFetchOpts.headers.firebaseIdToken).to.eq("some-firebase.id.token");
-        });
-
-        it("takes a validation flag", () => {
-            FloorApi.updatePlannedBuildingElements({
-                projectId: "some-project-id",
-                floorId: "some-floor-id"
-            }, [new ApiPlannedElement({
-                globalId: "some-global-id",
-                name: "some-name"
-            })], user, true);
-            const fetchCall = fetchMock.lastCall();
-            expect(fetchCall[0]).to.eq(`${Http.baseUrl()}/projects/some-project-id/floors/some-floor-id/planned-building-elements?validate=true`);
-        });
+      expect(lastFetchOpts.headers).to.include.keys("Content-Type");
+      expect(lastFetchOpts.headers["Content-Type"]).to.eq("application/json");
+      expect(fetchCall[0]).to.eq(`${Http.baseUrl()}/projects/some-project-id/floors/some-floor-id`);
+      expect(fetchCall[1].body).to.deep.eq(JSON.stringify(new ApiFloor({
+        defaultFirebaseScanDatasetId: "some-scan-id",
+        floorElevation: 10.0
+      })));
     });
 
-    describe("#getMasterformatProgresses", () => {
-        beforeEach(() => {
-            fetchMock.get(`${Http.baseUrl()}/projects/some-project-id/floors/some-floor-id/masterformat-progresses/BASELINE`, 200);
-            fetchMock.get(`${Http.baseUrl()}/projects/some-project-id/floors/some-floor-id/masterformat-progresses/CURRENT`, 200);
-            fetchMock.get(`${Http.baseUrl()}/projects/some-project-id/floors/some-floor-id/masterformat-progresses/SCANNED`, 200);
-        });
+    it("sends the request with authorization headers", () => {
+      FloorApi.updateFloor({
+        projectId: "some-project-id",
+        floorId: "some-floor-id"
+      }, new ApiFloor({
+        defaultFirebaseScanDatasetId: "some-scan-id"
+      }), user);
+      const fetchCall = fetchMock.lastCall();
+      const lastFetchOpts = fetchMock.lastOptions();
 
-        it("makes a call to the endpoint with the BASELINE progress type", () => {
-            FloorApi.getMasterformatProgress({
-                projectId: "some-project-id",
-                floorId: "some-floor-id"
-            }, ProgressType.BASELINE, user);
-            const fetchCall = fetchMock.lastCall();
-            expect(fetchCall[0]).to.eq(`${Http.baseUrl()}/projects/some-project-id/floors/some-floor-id/masterformat-progresses/BASELINE`);
-        });
-
-        it("makes a call to the endpoint with the CURRENT progress type", () => {
-            FloorApi.getMasterformatProgress({
-                projectId: "some-project-id",
-                floorId: "some-floor-id"
-            }, ProgressType.CURRENT, user);
-            const fetchCall = fetchMock.lastCall();
-            expect(fetchCall[0]).to.eq(`${Http.baseUrl()}/projects/some-project-id/floors/some-floor-id/masterformat-progresses/CURRENT`);
-        });
-
-        it("makes a call to the endpoint with the SCANNED progress type", () => {
-            FloorApi.getMasterformatProgress({
-                projectId: "some-project-id",
-                floorId: "some-floor-id"
-            }, ProgressType.SCANNED, user);
-            const fetchCall = fetchMock.lastCall();
-            expect(fetchCall[0]).to.eq(`${Http.baseUrl()}/projects/some-project-id/floors/some-floor-id/masterformat-progresses/SCANNED`);
-        });
-
-        it("sends the request with authorization headers", () => {
-            FloorApi.getMasterformatProgress({
-                projectId: "some-project-id",
-                floorId: "some-floor-id"
-            }, ProgressType.SCANNED, user);
-            const fetchCall = fetchMock.lastCall();
-            const lastFetchOpts = fetchMock.lastOptions();
-
-            expect(fetchCall[0]).to.eq(`${Http.baseUrl()}/projects/some-project-id/floors/some-floor-id/masterformat-progresses/SCANNED`);
-            expect(lastFetchOpts.headers).to.include.key("firebaseIdToken");
-            expect(lastFetchOpts.headers.firebaseIdToken).to.eq("some-firebase.id.token");
-        });
+      expect(fetchCall[0]).to.eq(`${Http.baseUrl()}/projects/some-project-id/floors/some-floor-id`);
+      expect(lastFetchOpts.headers).to.include.keys("firebaseIdToken");
+      expect(lastFetchOpts.headers.firebaseIdToken).to.eq("some-firebase.id.token");
     });
 
+    describe("when the call fails", () => {
+      beforeEach(() => {
+        fetchMock.patch(`${Http.baseUrl()}/projects/some-project-id/floors/some-floor-id`,
+          {
+            status: 500, body: { some: "body" },
+            headers: { "ContentType": "application/json" }
+          },
+          { overwriteRoutes: true });
+      });
 
-    describe("#setMasterformatProgress", () => {
-        beforeEach(() => {
-            fetchMock.post(`${Http.baseUrl()}/projects/some-project-id/floors/some-floor-id/masterformat-progresses/BASELINE`, 200);
-            fetchMock.post(`${Http.baseUrl()}/projects/some-project-id/floors/some-floor-id/masterformat-progresses/CURRENT`, 200);
-            fetchMock.post(`${Http.baseUrl()}/projects/some-project-id/floors/some-floor-id/masterformat-progresses/SCANNED`, 200);
-        });
-
-        it("makes a call to the endpoint", () => {
-            FloorApi.setMasterformatProgress({
-                projectId: "some-project-id",
-                floorId: "some-floor-id"
-            }, ProgressType.CURRENT, [new ApiMasterformatProgress({
-                masterformat: new ApiMasterformat(2016, "10 00 00", "Some Masterformat"),
-                percentComplete: 0.1,
-                scanDate: new Date("2023-05-01T12:00:00Z")
-            })], user);
-            const fetchCall = fetchMock.lastCall();
-            const lastFetchOpts = fetchMock.lastOptions();
-
-            expect(lastFetchOpts.headers).to.include.key("Content-Type");
-            expect(lastFetchOpts.headers["Content-Type"]).to.eq("application/json");
-            expect(fetchCall[0]).to.eq(`${Http.baseUrl()}/projects/some-project-id/floors/some-floor-id/masterformat-progresses/CURRENT`);
-            expect(fetchCall[1].body).to.deep.eq(JSON.stringify([new ApiMasterformatProgress({
-                    masterformat: new ApiMasterformat(2016, "10 00 00", "Some Masterformat"),
-                    percentComplete: 0.1,
-                    scanDate: new Date("2023-05-01T12:00:00Z")
-                })]
-            ));
-        });
-
-        it("sends the request with authorization headers", () => {
-            FloorApi.setMasterformatProgress({
-                projectId: "some-project-id",
-                floorId: "some-floor-id"
-            }, ProgressType.CURRENT, [new ApiMasterformatProgress({
-                masterformat: new ApiMasterformat(2016, "10 00 00", "Some Masterformat"),
-                percentComplete: 0.1,
-                scanDate: new Date("2023-05-01T12:00:00Z")
-            })], user);
-            const fetchCall = fetchMock.lastCall();
-            const lastFetchOpts = fetchMock.lastOptions();
-
-            expect(fetchCall[0]).to.eq(`${Http.baseUrl()}/projects/some-project-id/floors/some-floor-id/masterformat-progresses/CURRENT`);
-            expect(lastFetchOpts.headers).to.include.key("firebaseIdToken");
-            expect(lastFetchOpts.headers.firebaseIdToken).to.eq("some-firebase.id.token");
-        });
-    });
-
-    describe("#generateMasterformatProgresses", () => {
-        beforeEach(() => {
-            fetchMock.post(`${Http.baseUrl()}/projects/some-project-id/floors/some-floor-id/generate-masterformat-progress?masterformatVersion=2016&reportDate=2023-05-01T12:00:00.000Z`, 200);
-        });
-
-        it("makes a call to the endpoint with the right parameters in the url", () => {
-            FloorApi.generateMasterformatProgress(
-                {
-                    projectId: "some-project-id",
-                    floorId: "some-floor-id"
-                },
-                new Date("2023-05-01T12:00:00Z"),
-                2016, user);
-            const fetchCall = fetchMock.lastCall();
-            expect(fetchCall[0]).to.eq(`${Http.baseUrl()}/projects/some-project-id/floors/some-floor-id/generate-masterformat-progress?masterformatVersion=2016&reportDate=2023-05-01T12:00:00.000Z`);
-        });
-
-        it("sends the request with authorization headers", () => {
-            FloorApi.generateMasterformatProgress({
-                projectId: "some-project-id",
-                floorId: "some-floor-id"
+      it("dispatches an api failure notification", () => {
+        sandbox.stub(Config, "sharedErrorHandler");
+        return FloorApi.updateFloor({
+              projectId: "some-project-id",
+              floorId: "some-floor-id"
             },
-                new Date("2023-05-01T12:00:00Z"),
-                2016,
-                user);
-            const fetchCall = fetchMock.lastCall();
-            const lastFetchOpts = fetchMock.lastOptions();
-
-            expect(fetchCall[0]).to.eq(`${Http.baseUrl()}/projects/some-project-id/floors/some-floor-id/generate-masterformat-progress?masterformatVersion=2016&reportDate=2023-05-01T12:00:00.000Z`);
-            expect(lastFetchOpts.headers).to.include.key("firebaseIdToken");
-            expect(lastFetchOpts.headers.firebaseIdToken).to.eq("some-firebase.id.token");
-        });
+            new ApiFloor({
+              defaultFirebaseScanDatasetId: "some-scan-id"
+            }),
+            { firebaseUser: { idToken: "some-firebase.id.token" } } as User)
+          .catch(_.noop)
+          .finally(() => {
+            expect(Config.sharedErrorHandler).to.have.been.calledWithMatch({});
+          });
+      });
     });
+  });
+
+  describe("#reorderFloors", () => {
+    const requestBody = [];
+    const associationIds = { projectId: "some-project-id" };
+    beforeEach(() => {
+      fetchMock.post(`${Http.baseUrl()}/projects/some-project-id/floors/reorder-floors`, {
+        status: 200,
+        body: requestBody
+      });
+    });
+
+    it("makes a call to the correct endpoint", () => {
+      FloorApi.reorderFloors(associationIds, requestBody, user);
+      const fetchCall = fetchMock.lastCall();
+      expect(fetchCall[0]).to.eq(`${Http.baseUrl()}/projects/some-project-id/floors/reorder-floors`);
+    });
+
+    it("sends the request with authorization headers", () => {
+      FloorApi.reorderFloors(associationIds, requestBody, user);
+      const lastFetchOpts = fetchMock.lastOptions();
+      expect(lastFetchOpts.headers).to.include.keys("firebaseIdToken");
+      expect(lastFetchOpts.headers.firebaseIdToken).to.eq("some-firebase.id.token");
+    });
+  });
+
+  describe("#deleteFloor", () => {
+    beforeEach(() => {
+      fetchMock.delete(`${Http.baseUrl()}/projects/some-project-id/floors/some-floor-id`, 200);
+    });
+
+    it("makes a call to the correct endpoint", () => {
+      FloorApi.deleteFloor({
+        projectId: "some-project-id",
+        floorId: "some-floor-id",
+        deletionModeSelection: ""
+      }, { firebaseUser: { idToken: "some-firebase.id.token" } } as User);
+      const fetchCall = fetchMock.lastCall();
+      const lastFetchOpts = fetchMock.lastOptions();
+
+      expect(lastFetchOpts.headers).to.include.keys("Content-Type");
+      expect(lastFetchOpts.headers["Content-Type"]).to.eq("application/json");
+      expect(fetchCall[0]).to.eq(`${Http.baseUrl()}/projects/some-project-id/floors/some-floor-id`);
+    });
+
+    it("sends the request with authorization headers", () => {
+      FloorApi.deleteFloor({
+        projectId: "some-project-id",
+        floorId: "some-floor-id",
+        deletionModeSelection: ""
+      }, user);
+      const fetchCall = fetchMock.lastCall();
+      const lastFetchOpts = fetchMock.lastOptions();
+
+      expect(fetchCall[0]).to.eq(`${Http.baseUrl()}/projects/some-project-id/floors/some-floor-id`);
+      expect(lastFetchOpts.headers).to.include.key("firebaseIdToken");
+      expect(lastFetchOpts.headers.firebaseIdToken).to.eq("some-firebase.id.token");
+    });
+
+    describe("when the call fails", () => {
+      beforeEach(() => {
+        fetchMock.delete(`${Http.baseUrl()}/projects/some-project-id/floors/some-floor-id`,
+          {
+            status: 500, body: { some: "body" },
+            headers: { "ContentType": "application/json" }
+          },
+          { overwriteRoutes: true });
+      });
+
+      it("dispatches an api failure notification", () => {
+        sandbox.stub(Config, "sharedErrorHandler");
+        return FloorApi.deleteFloor({
+              projectId: "some-project-id",
+              floorId: "some-floor-id",
+              deletionModeSelection: ""
+            },
+            { firebaseUser: { idToken: "some-firebase.id.token" } } as User)
+          .catch(_.noop)
+          .finally(() => {
+            expect(Config.sharedErrorHandler).to.have.been.calledWithMatch({});
+          });
+      });
+    });
+
+    describe("delete floors with deletion mode selection", () => {
+      beforeEach(() => {
+        fetchMock.delete(`${Http.baseUrl()}/projects/some-project-id/floors/some-floor-id?deletionModeSelection=${ApiFloorFileDeletionMode.ALL_FILES}`,
+          200);
+      });
+
+      it("delete floor with deletion mode ALL_FILES", () => {
+        FloorApi.deleteFloor({
+          projectId: "some-project-id",
+          floorId: "some-floor-id",
+          deletionModeSelection: "ALL_FILES"
+        }, user);
+
+        const fetchCall = fetchMock.lastCall();
+        const lastFetchOpts = fetchMock.lastOptions();
+
+        expect(fetchCall[0])
+          .to
+          .eq(`${Http.baseUrl()}/projects/some-project-id/floors/some-floor-id?deletionModeSelection=${ApiFloorFileDeletionMode.ALL_FILES}`);
+        expect(lastFetchOpts.headers).to.include.key("firebaseIdToken");
+        expect(lastFetchOpts.headers.firebaseIdToken).to.eq("some-firebase.id.token");
+      });
+    });
+  });
+
+  describe("#updatePlannedBuildingElements", () => {
+    beforeEach(() => {
+      fetchMock.patch(`${Http.baseUrl()}/projects/some-project-id/floors/some-floor-id/planned-building-elements?validate=false`,
+        200);
+      fetchMock.patch(`${Http.baseUrl()}/projects/some-project-id/floors/some-floor-id/planned-building-elements?validate=true`,
+        200);
+    });
+
+    it("makes a call to the endpoint", () => {
+      FloorApi.updatePlannedBuildingElements({
+        projectId: "some-project-id",
+        floorId: "some-floor-id"
+      }, [new ApiPlannedElement({
+        globalId: "some-global-id",
+        name: "some-name"
+      })], user);
+      const fetchCall = fetchMock.lastCall();
+      const lastFetchOpts = fetchMock.lastOptions();
+
+      expect(lastFetchOpts.headers).to.include.key("Content-Type");
+      expect(lastFetchOpts.headers["Content-Type"]).to.eq("application/json");
+      expect(fetchCall[0])
+        .to
+        .eq(`${Http.baseUrl()}/projects/some-project-id/floors/some-floor-id/planned-building-elements?validate=false`);
+      expect(fetchCall[1].body).to.deep.eq(JSON.stringify([new ApiPlannedElement({
+          globalId: "some-global-id",
+          name: "some-name"
+        })]
+      ));
+    });
+
+    it("sends the request with authorization headers", () => {
+      FloorApi.updatePlannedBuildingElements({
+        projectId: "some-project-id",
+        floorId: "some-floor-id"
+      }, [new ApiPlannedElement({
+        globalId: "some-global-id",
+        name: "some-name"
+      })], user);
+      const fetchCall = fetchMock.lastCall();
+      const lastFetchOpts = fetchMock.lastOptions();
+
+      expect(fetchCall[0])
+        .to
+        .eq(`${Http.baseUrl()}/projects/some-project-id/floors/some-floor-id/planned-building-elements?validate=false`);
+      expect(lastFetchOpts.headers).to.include.key("firebaseIdToken");
+      expect(lastFetchOpts.headers.firebaseIdToken).to.eq("some-firebase.id.token");
+    });
+
+    it("takes a validation flag", () => {
+      FloorApi.updatePlannedBuildingElements({
+        projectId: "some-project-id",
+        floorId: "some-floor-id"
+      }, [new ApiPlannedElement({
+        globalId: "some-global-id",
+        name: "some-name"
+      })], user, true);
+      const fetchCall = fetchMock.lastCall();
+      expect(fetchCall[0])
+        .to
+        .eq(`${Http.baseUrl()}/projects/some-project-id/floors/some-floor-id/planned-building-elements?validate=true`);
+    });
+  });
+
+  describe("#getMasterformatProgresses", () => {
+    beforeEach(() => {
+      fetchMock.get(`${Http.baseUrl()}/projects/some-project-id/floors/some-floor-id/masterformat-progresses/BASELINE`,
+        200);
+      fetchMock.get(`${Http.baseUrl()}/projects/some-project-id/floors/some-floor-id/masterformat-progresses/CURRENT`,
+        200);
+      fetchMock.get(`${Http.baseUrl()}/projects/some-project-id/floors/some-floor-id/masterformat-progresses/SCANNED`,
+        200);
+    });
+
+    it("makes a call to the endpoint with the BASELINE progress type", () => {
+      FloorApi.getMasterformatProgress({
+        projectId: "some-project-id",
+        floorId: "some-floor-id"
+      }, ProgressType.BASELINE, user);
+      const fetchCall = fetchMock.lastCall();
+      expect(fetchCall[0])
+        .to
+        .eq(`${Http.baseUrl()}/projects/some-project-id/floors/some-floor-id/masterformat-progresses/BASELINE`);
+    });
+
+    it("makes a call to the endpoint with the CURRENT progress type", () => {
+      FloorApi.getMasterformatProgress({
+        projectId: "some-project-id",
+        floorId: "some-floor-id"
+      }, ProgressType.CURRENT, user);
+      const fetchCall = fetchMock.lastCall();
+      expect(fetchCall[0])
+        .to
+        .eq(`${Http.baseUrl()}/projects/some-project-id/floors/some-floor-id/masterformat-progresses/CURRENT`);
+    });
+
+    it("makes a call to the endpoint with the SCANNED progress type", () => {
+      FloorApi.getMasterformatProgress({
+        projectId: "some-project-id",
+        floorId: "some-floor-id"
+      }, ProgressType.SCANNED, user);
+      const fetchCall = fetchMock.lastCall();
+      expect(fetchCall[0])
+        .to
+        .eq(`${Http.baseUrl()}/projects/some-project-id/floors/some-floor-id/masterformat-progresses/SCANNED`);
+    });
+
+    it("sends the request with authorization headers", () => {
+      FloorApi.getMasterformatProgress({
+        projectId: "some-project-id",
+        floorId: "some-floor-id"
+      }, ProgressType.SCANNED, user);
+      const fetchCall = fetchMock.lastCall();
+      const lastFetchOpts = fetchMock.lastOptions();
+
+      expect(fetchCall[0])
+        .to
+        .eq(`${Http.baseUrl()}/projects/some-project-id/floors/some-floor-id/masterformat-progresses/SCANNED`);
+      expect(lastFetchOpts.headers).to.include.key("firebaseIdToken");
+      expect(lastFetchOpts.headers.firebaseIdToken).to.eq("some-firebase.id.token");
+    });
+  });
+
+
+  describe("#setMasterformatProgress", () => {
+    beforeEach(() => {
+      fetchMock.post(`${Http.baseUrl()}/projects/some-project-id/floors/some-floor-id/masterformat-progresses/BASELINE`,
+        200);
+      fetchMock.post(`${Http.baseUrl()}/projects/some-project-id/floors/some-floor-id/masterformat-progresses/CURRENT`,
+        200);
+      fetchMock.post(`${Http.baseUrl()}/projects/some-project-id/floors/some-floor-id/masterformat-progresses/SCANNED`,
+        200);
+    });
+
+    it("makes a call to the endpoint", () => {
+      FloorApi.setMasterformatProgress({
+        projectId: "some-project-id",
+        floorId: "some-floor-id"
+      }, ProgressType.CURRENT, [new ApiMasterformatProgress({
+        masterformat: new ApiMasterformat(2016, "10 00 00", "Some Masterformat"),
+        percentComplete: 0.1,
+        scanDate: new Date("2023-05-01T12:00:00Z")
+      })], user);
+      const fetchCall = fetchMock.lastCall();
+      const lastFetchOpts = fetchMock.lastOptions();
+
+      expect(lastFetchOpts.headers).to.include.key("Content-Type");
+      expect(lastFetchOpts.headers["Content-Type"]).to.eq("application/json");
+      expect(fetchCall[0])
+        .to
+        .eq(`${Http.baseUrl()}/projects/some-project-id/floors/some-floor-id/masterformat-progresses/CURRENT`);
+      expect(fetchCall[1].body).to.deep.eq(JSON.stringify([new ApiMasterformatProgress({
+          masterformat: new ApiMasterformat(2016, "10 00 00", "Some Masterformat"),
+          percentComplete: 0.1,
+          scanDate: new Date("2023-05-01T12:00:00Z")
+        })]
+      ));
+    });
+
+    it("sends the request with authorization headers", () => {
+      FloorApi.setMasterformatProgress({
+        projectId: "some-project-id",
+        floorId: "some-floor-id"
+      }, ProgressType.CURRENT, [new ApiMasterformatProgress({
+        masterformat: new ApiMasterformat(2016, "10 00 00", "Some Masterformat"),
+        percentComplete: 0.1,
+        scanDate: new Date("2023-05-01T12:00:00Z")
+      })], user);
+      const fetchCall = fetchMock.lastCall();
+      const lastFetchOpts = fetchMock.lastOptions();
+
+      expect(fetchCall[0])
+        .to
+        .eq(`${Http.baseUrl()}/projects/some-project-id/floors/some-floor-id/masterformat-progresses/CURRENT`);
+      expect(lastFetchOpts.headers).to.include.key("firebaseIdToken");
+      expect(lastFetchOpts.headers.firebaseIdToken).to.eq("some-firebase.id.token");
+    });
+  });
+
+  describe("#generateMasterformatProgresses", () => {
+    beforeEach(() => {
+      fetchMock.post(`${Http.baseUrl()}/projects/some-project-id/floors/some-floor-id/generate-masterformat-progress?masterformatVersion=2016&reportDate=2023-05-01T12:00:00.000Z`,
+        200);
+    });
+
+    it("makes a call to the endpoint with the right parameters in the url", () => {
+      FloorApi.generateMasterformatProgress(
+        {
+          projectId: "some-project-id",
+          floorId: "some-floor-id"
+        },
+        new Date("2023-05-01T12:00:00Z"),
+        2016, user);
+      const fetchCall = fetchMock.lastCall();
+      expect(fetchCall[0])
+        .to
+        .eq(`${Http.baseUrl()}/projects/some-project-id/floors/some-floor-id/generate-masterformat-progress?masterformatVersion=2016&reportDate=2023-05-01T12:00:00.000Z`);
+    });
+
+    it("sends the request with authorization headers", () => {
+      FloorApi.generateMasterformatProgress({
+          projectId: "some-project-id",
+          floorId: "some-floor-id"
+        },
+        new Date("2023-05-01T12:00:00Z"),
+        2016,
+        user);
+      const fetchCall = fetchMock.lastCall();
+      const lastFetchOpts = fetchMock.lastOptions();
+
+      expect(fetchCall[0])
+        .to
+        .eq(`${Http.baseUrl()}/projects/some-project-id/floors/some-floor-id/generate-masterformat-progress?masterformatVersion=2016&reportDate=2023-05-01T12:00:00.000Z`);
+      expect(lastFetchOpts.headers).to.include.key("firebaseIdToken");
+      expect(lastFetchOpts.headers.firebaseIdToken).to.eq("some-firebase.id.token");
+    });
+  });
 
 });

--- a/tests/api/report_api_test.ts
+++ b/tests/api/report_api_test.ts
@@ -1,238 +1,251 @@
-import {describe} from "mocha";
-import {User} from "../../source/models/domain/user";
+import { describe } from "mocha";
+import { expect } from "chai";
 // @ts-ignore
 import fetchMock from "fetch-mock";
-import {UserAuthType} from "../../source/models/enums/user_auth_type";
-import {UserRole} from "../../source/models/enums/user_role";
+
 import Http from "../../source/utilities/http";
-import {expect} from "chai";
 import ReportApi from "../../source/api/report_api";
-import {ApiInspectReport, ApiInspectReportEntry, ApiPlannedElement} from "../../source";
+import { ApiInspectReport, ApiInspectReportEntry } from "../../source";
+import { User } from "../../source/models/domain/user";
+import { UserAuthType } from "../../source/models/enums/user_auth_type";
+import { UserRole } from "../../source/models/enums/user_role";
 
 describe("ReportApi", () => {
-    let user: User;
+  let user: User;
+  beforeEach(() => {
+    fetchMock.resetBehavior();
+    user = {
+      authType: UserAuthType.FIREBASE,
+      firebaseUser: { uid: "some-uid", role: UserRole.SUPERADMIN, idToken: "some-firebase.id.token" }
+    };
+  });
+
+  describe("::listInspectReports", () => {
     beforeEach(() => {
-        fetchMock.resetBehavior();
-        user = {
-            authType: UserAuthType.FIREBASE,
-            firebaseUser: {uid: "some-uid", role: UserRole.SUPERADMIN, idToken: "some-firebase.id.token"}
-        };
+      fetchMock.get(`${Http.baseUrl()}/projects/some-project-id/reports`, 200);
     });
-    describe("listInspectReports", () => {
-        beforeEach(() => {
-            fetchMock.get(`${Http.baseUrl()}/projects/some-project-id/reports`, 200);
-        });
-        it('makes a request to the gateway', () => {
-            ReportApi.listInspectReports({projectId: "some-project-id"}, user);
-            const fetchCall = fetchMock.lastCall();
-            expect(fetchCall[0]).to.eq(`${Http.baseUrl()}/projects/some-project-id/reports`);
-            expect(fetchMock.lastOptions().headers.Accept).to.eq("application/json");
-        });
-        it("sends the request with Authorization header", () => {
-            ReportApi.listInspectReports({projectId: "some-project-id"}, {
-                authType: UserAuthType.GATEWAY_JWT,
-                gatewayUser: {idToken: "some-firebase.id.token", role: UserRole.USER}
-            });
-            expect(fetchMock.lastOptions().headers.Authorization).to.eq("Bearer some-firebase.id.token");
-        });
+
+    it("makes a request to the gateway", () => {
+      ReportApi.listInspectReports({ projectId: "some-project-id" }, user);
+      const fetchCall = fetchMock.lastCall();
+      expect(fetchCall[0]).to.eq(`${Http.baseUrl()}/projects/some-project-id/reports`);
+      expect(fetchMock.lastOptions().headers.Accept).to.eq("application/json");
     });
-    describe("createInspectReport", () => {
-        beforeEach(() => {
-            fetchMock.post(`${Http.baseUrl()}/projects/some-project-id/reports`, 200);
-        });
 
-        it("makes a request to the gateway api", () => {
-            ReportApi.createInspectReport({
-                    projectId: "some-project-id"
-                },
-                new ApiInspectReport({
-                    firebaseProjectId: "some-project-id",
-                    name: "some report name",
-                }), {
-                    authType: "GATEWAY_JWT",
-                    gatewayUser: {idToken: "some-firebase.id.token"}
-                } as User);
-
-            const fetchCall = fetchMock.lastCall();
-
-            expect(fetchCall[0]).to.eq(`${Http.baseUrl()}/projects/some-project-id/reports`);
-            expect(JSON.parse(fetchCall[1].body as string)).to.deep.eq({
-                firebaseProjectId: "some-project-id",
-                name: "some report name",
-                entries: []
-            });
-            expect(fetchMock.lastOptions().headers.Accept).to.eq("application/json");
-        });
-
-        it("includes the authorization headers", () => {
-            ReportApi.createInspectReport({
-                    projectId: "some-project-id"
-                },
-                new ApiInspectReport({
-                    firebaseProjectId: "some-project-id",
-                    name: "some report name",
-                }), {
-                    authType: "GATEWAY_JWT",
-                    gatewayUser: {idToken: "some-firebase.id.token"}
-                } as User);
-
-            expect(fetchMock.lastOptions().headers.Authorization).to.eq("Bearer some-firebase.id.token");
-        });
+    it("sends the request with Authorization header", () => {
+      ReportApi.listInspectReports({ projectId: "some-project-id" }, {
+        authType: UserAuthType.GATEWAY_JWT,
+        gatewayUser: { idToken: "some-firebase.id.token", role: UserRole.USER }
+      });
+      expect(fetchMock.lastOptions().headers.Authorization).to.eq("Bearer some-firebase.id.token");
     });
-    describe("createInspectReportEntry", () => {
-        beforeEach(() => {
-            fetchMock.post(`${Http.baseUrl()}/projects/some-project-id/reports/7/inspect-entries`, 200);
-        });
+  });
 
-        it("makes a request to the gateway api", () => {
-            ReportApi.createInspectReportEntries({
-                    projectId: "some-project-id",
-                    inspectReportId: 7
-                },
-                new ApiInspectReportEntry({
-                    reportId: 7,
-                    name: "some entry name",
-                    elements: [new ApiPlannedElement({globalId: "Obj2"})]
-                }), {
-                    authType: "GATEWAY_JWT",
-                    gatewayUser: {idToken: "some-firebase.id.token"}
-                } as User);
-
-            const fetchCall = fetchMock.lastCall();
-
-            expect(fetchCall[0]).to.eq(`${Http.baseUrl()}/projects/some-project-id/reports/7/inspect-entries`);
-            expect(JSON.parse(fetchCall[1].body as string)).to.deep.eq({
-                reportId: 7,
-                name: "some entry name",
-                elements: [{globalId: "Obj2"}]
-            });
-            expect(fetchMock.lastOptions().headers.Accept).to.eq("application/json");
-        });
-
-        it("includes the authorization headers", () => {
-            ReportApi.createInspectReportEntries({
-                    projectId: "some-project-id",
-                    inspectReportId: 7
-                },
-                new ApiInspectReportEntry({
-                    reportId: 7,
-                    name: "some entry name",
-                    elementId: 2
-                }), {
-                    authType: "GATEWAY_JWT",
-                    gatewayUser: {idToken: "some-firebase.id.token"}
-                } as User);
-
-            expect(fetchMock.lastOptions().headers.Authorization).to.eq("Bearer some-firebase.id.token");
-        });
+  describe("::createInspectReport", () => {
+    beforeEach(() => {
+      fetchMock.post(`${Http.baseUrl()}/projects/some-project-id/reports`, 200);
     });
-    describe("deleteInspectReportEntry", () => {
-        beforeEach(() => {
-            fetchMock.delete(`${Http.baseUrl()}/projects/some-project-id/reports/7/inspect-entries/9`, 200);
-        });
-        it("makes a request to the gateway api", () => {
-            ReportApi.deleteInspectReportEntry({
-                projectId: "some-project-id",
-                inspectReportId: 7,
-                inspectReportEntryId: 9
-            }, {
-                authType: "GATEWAY_JWT",
-                gatewayUser: {idToken: "some-firebase.id.token"}
-            } as User);
-            const fetchCall = fetchMock.lastCall();
-            expect(fetchCall[0]).to.eq(`${Http.baseUrl()}/projects/some-project-id/reports/7/inspect-entries/9`);
-            expect(fetchMock.lastOptions().headers.Accept).to.eq("application/json");
-        });
-        it("includes the authorization headers", () => {
-            ReportApi.deleteInspectReportEntry({
-                    projectId: "some-project-id",
-                    inspectReportId: 7,
-                    inspectReportEntryId: 9
-                }, {
-                    authType: "GATEWAY_JWT",
-                    gatewayUser: {idToken: "some-firebase.id.token"}
-                } as User);
-            expect(fetchMock.lastOptions().headers.Authorization).to.eq("Bearer some-firebase.id.token");
-        });
+
+    it("makes a request to the gateway api", () => {
+      ReportApi.createInspectReport({
+          projectId: "some-project-id"
+        },
+        new ApiInspectReport({
+          firebaseProjectId: "some-project-id",
+          name: "some report name",
+        }), {
+          authType: "GATEWAY_JWT",
+          gatewayUser: { idToken: "some-firebase.id.token" }
+        } as User);
+
+      const fetchCall = fetchMock.lastCall();
+
+      expect(fetchCall[0]).to.eq(`${Http.baseUrl()}/projects/some-project-id/reports`);
+      expect(JSON.parse(fetchCall[1].body as string)).to.deep.eq({
+        firebaseProjectId: "some-project-id",
+        name: "some report name",
+        entries: []
+      });
+      expect(fetchMock.lastOptions().headers.Accept).to.eq("application/json");
     });
-    describe("updateInspectReport", () => {
-        beforeEach(() => {
-            fetchMock.put(`${Http.baseUrl()}/projects/some-project-id/reports/7`, 200);
-        });
 
-        it("makes a request to the gateway api", () => {
-            ReportApi.updateInspectReport({
-                    projectId: "some-project-id",
-                    inspectReportId: 7
-                },
-                new ApiInspectReport({
-                    id: 7,
-                    firebaseProjectId: "some-project-id",
-                    name: "some report name",
-                }), {
-                    authType: "GATEWAY_JWT",
-                    gatewayUser: {idToken: "some-firebase.id.token"}
-                } as User);
+    it("includes the authorization headers", () => {
+      ReportApi.createInspectReport({
+          projectId: "some-project-id"
+        },
+        new ApiInspectReport({
+          firebaseProjectId: "some-project-id",
+          name: "some report name",
+        }), {
+          authType: "GATEWAY_JWT",
+          gatewayUser: { idToken: "some-firebase.id.token" }
+        } as User);
 
-            const fetchCall = fetchMock.lastCall();
-
-            expect(fetchCall[0]).to.eq(`${Http.baseUrl()}/projects/some-project-id/reports/7`);
-            expect(JSON.parse(fetchCall[1].body as string)).to.deep.eq({
-                "entries": [],
-                "firebaseProjectId": "some-project-id",
-                "id": 7,
-                "name": "some report name"
-            });
-            expect(fetchMock.lastOptions().headers.Accept).to.eq("application/json");
-        });
-
-        it("includes the authorization headers", () => {
-            ReportApi.updateInspectReport({
-                    projectId: "some-project-id",
-                    inspectReportId: 7
-                },
-                new ApiInspectReport({
-                    id: 7,
-                    firebaseProjectId: "some-project-id",
-                    name: "some report name",
-                }), {
-                    authType: "GATEWAY_JWT",
-                    gatewayUser: {idToken: "some-firebase.id.token"}
-                } as User);
-
-            expect(fetchMock.lastOptions().headers.Authorization).to.eq("Bearer some-firebase.id.token");
-        });
+      expect(fetchMock.lastOptions().headers.Authorization).to.eq("Bearer some-firebase.id.token");
     });
-    describe("deleteInspectReport", () => {
-        beforeEach(() => {
-            fetchMock.delete(`${Http.baseUrl()}/projects/some-project-id/reports/7`, 200);
-        });
+  });
 
-        it("makes a request to the gateway api", () => {
-            ReportApi.deleteInspectReport({
-                projectId: "some-project-id",
-                inspectReportId: 7
-            }, {
-                authType: "GATEWAY_JWT",
-                gatewayUser: {idToken: "some-firebase.id.token"}
-            } as User);
-
-            const fetchCall = fetchMock.lastCall();
-
-            expect(fetchCall[0]).to.eq(`${Http.baseUrl()}/projects/some-project-id/reports/7`);
-            expect(fetchMock.lastOptions().headers.Accept).to.eq("application/json");
-        });
-
-        it("includes the authorization headers", () => {
-            ReportApi.deleteInspectReport({
-                projectId: "some-project-id",
-                inspectReportId: 7
-            }, {
-                authType: "GATEWAY_JWT",
-                gatewayUser: {idToken: "some-firebase.id.token"}
-            } as User);
-
-            expect(fetchMock.lastOptions().headers.Authorization).to.eq("Bearer some-firebase.id.token");
-        });
+  describe("::createInspectReportEntry", () => {
+    beforeEach(() => {
+      fetchMock.post(`${Http.baseUrl()}/projects/some-project-id/reports/7/inspect-entries`, 200);
     });
+
+    it("makes a request to the gateway api", () => {
+      ReportApi.createInspectReportEntries({
+          projectId: "some-project-id",
+          inspectReportId: 7
+        },
+        [new ApiInspectReportEntry({
+          reportId: 7,
+          name: "some entry name",
+          elements: [{ globalId: "Obj2" }]
+        })], {
+          authType: "GATEWAY_JWT",
+          gatewayUser: { idToken: "some-firebase.id.token" }
+        } as User);
+
+      const fetchCall = fetchMock.lastCall();
+
+      expect(fetchCall[0]).to.eq(`${Http.baseUrl()}/projects/some-project-id/reports/7/inspect-entries`);
+      expect(JSON.parse(fetchCall[1].body as string)).to.deep.eq([{
+        reportId: 7,
+        name: "some entry name",
+        elements: [{ globalId: "Obj2" }],
+        obstructedTrades: [],
+        obstructingTrades: []
+      }]);
+      expect(fetchMock.lastOptions().headers.Accept).to.eq("application/json");
+    });
+
+    it("includes the authorization headers", () => {
+      ReportApi.createInspectReportEntries({
+          projectId: "some-project-id",
+          inspectReportId: 7
+        },
+        [new ApiInspectReportEntry({
+          reportId: 7,
+          name: "some entry name",
+          elements: [{ globalId: "Obj2" }]
+        })], {
+          authType: "GATEWAY_JWT",
+          gatewayUser: { idToken: "some-firebase.id.token" }
+        } as User);
+
+      expect(fetchMock.lastOptions().headers.Authorization).to.eq("Bearer some-firebase.id.token");
+    });
+  });
+
+  describe("::deleteInspectReportEntry", () => {
+    beforeEach(() => {
+      fetchMock.delete(`${Http.baseUrl()}/projects/some-project-id/reports/7/inspect-entries/9`, 200);
+    });
+
+    it("makes a request to the gateway api", () => {
+      ReportApi.deleteInspectReportEntry({
+        projectId: "some-project-id",
+        inspectReportId: 7,
+        inspectReportEntryId: 9
+      }, {
+        authType: "GATEWAY_JWT",
+        gatewayUser: { idToken: "some-firebase.id.token" }
+      } as User);
+      const fetchCall = fetchMock.lastCall();
+      expect(fetchCall[0]).to.eq(`${Http.baseUrl()}/projects/some-project-id/reports/7/inspect-entries/9`);
+      expect(fetchMock.lastOptions().headers.Accept).to.eq("application/json");
+    });
+
+    it("includes the authorization headers", () => {
+      ReportApi.deleteInspectReportEntry({
+        projectId: "some-project-id",
+        inspectReportId: 7,
+        inspectReportEntryId: 9
+      }, {
+        authType: "GATEWAY_JWT",
+        gatewayUser: { idToken: "some-firebase.id.token" }
+      } as User);
+      expect(fetchMock.lastOptions().headers.Authorization).to.eq("Bearer some-firebase.id.token");
+    });
+  });
+
+  describe("::updateInspectReport", () => {
+    beforeEach(() => {
+      fetchMock.put(`${Http.baseUrl()}/projects/some-project-id/reports/7`, 200);
+    });
+
+    it("makes a request to the gateway api", () => {
+      ReportApi.updateInspectReport({
+          projectId: "some-project-id",
+          inspectReportId: 7
+        },
+        new ApiInspectReport({
+          id: 7,
+          firebaseProjectId: "some-project-id",
+          name: "some report name",
+        }), {
+          authType: "GATEWAY_JWT",
+          gatewayUser: { idToken: "some-firebase.id.token" }
+        } as User);
+
+      const fetchCall = fetchMock.lastCall();
+
+      expect(fetchCall[0]).to.eq(`${Http.baseUrl()}/projects/some-project-id/reports/7`);
+      expect(JSON.parse(fetchCall[1].body as string)).to.deep.eq({
+        "entries": [],
+        "firebaseProjectId": "some-project-id",
+        "id": 7,
+        "name": "some report name"
+      });
+      expect(fetchMock.lastOptions().headers.Accept).to.eq("application/json");
+    });
+
+    it("includes the authorization headers", () => {
+      ReportApi.updateInspectReport({
+          projectId: "some-project-id",
+          inspectReportId: 7
+        },
+        new ApiInspectReport({
+          id: 7,
+          firebaseProjectId: "some-project-id",
+          name: "some report name",
+        }), {
+          authType: "GATEWAY_JWT",
+          gatewayUser: { idToken: "some-firebase.id.token" }
+        } as User);
+
+      expect(fetchMock.lastOptions().headers.Authorization).to.eq("Bearer some-firebase.id.token");
+    });
+  });
+
+  describe("::deleteInspectReport", () => {
+    beforeEach(() => {
+      fetchMock.delete(`${Http.baseUrl()}/projects/some-project-id/reports/7`, 200);
+    });
+
+    it("makes a request to the gateway api", () => {
+      ReportApi.deleteInspectReport({
+        projectId: "some-project-id",
+        inspectReportId: 7
+      }, {
+        authType: "GATEWAY_JWT",
+        gatewayUser: { idToken: "some-firebase.id.token" }
+      } as User);
+
+      const fetchCall = fetchMock.lastCall();
+
+      expect(fetchCall[0]).to.eq(`${Http.baseUrl()}/projects/some-project-id/reports/7`);
+      expect(fetchMock.lastOptions().headers.Accept).to.eq("application/json");
+    });
+
+    it("includes the authorization headers", () => {
+      ReportApi.deleteInspectReport({
+        projectId: "some-project-id",
+        inspectReportId: 7
+      }, {
+        authType: "GATEWAY_JWT",
+        gatewayUser: { idToken: "some-firebase.id.token" }
+      } as User);
+
+      expect(fetchMock.lastOptions().headers.Authorization).to.eq("Bearer some-firebase.id.token");
+    });
+  });
 });


### PR DESCRIPTION
Include the new models and api in the package's exports
- Rename some type names to be more consistent [Breaking]