### PR TITLE
integrate jira api to create service tickets from operations page [CAP-877]

### DIFF
--- a/source/api/integrations_api.ts
+++ b/source/api/integrations_api.ts
@@ -22,6 +22,9 @@ import {IntegrationAssociationIds} from "../models/api/integrations/integration_
 import ApiReviztoAccessToken from "../models/api/integrations/revizto/api_access_token";
 import ApiReviztoData from "../models/api/integrations/revizto/api_get_data";
 import {ReviztoIssueFields} from "../models/api/integrations/revizto/api_issue_fields";
+import {JiraIssueRequest} from "../models/api/integrations/jira/JiraIssueRequest";
+import {ApiResponse} from "../models/api/integrations/jira/ApiResponse";
+import {JiraIssueRequestModel} from "../models/api/integrations/jira/JiraIssueRequestModel";
 
 export default class IntegrationsApi {
 
@@ -373,6 +376,15 @@ export default class IntegrationsApi {
     static getAllCreatedIssuesForDeviatedElements(user: User, ids: ElementIdentifiers[]): Promise<{ toolName: string, issueId: string, id:number }[]> {
         let url = `${Http.baseUrl()}/integrations/tools/issues`;
         return Http.post(url,user, ids) as unknown as Promise<{ toolName: string, issueId: string, id:number }[]>;
+    }
+
+    static createJiraServiceDeskTicket(jiraIssueRequestModel: JiraIssueRequestModel,
+                                     user: User): Promise<ApiResponse> {
+        if (jiraIssueRequestModel) {
+            const url = `${Http.baseUrl()}/integrations/jira/create-ticket`;
+            const jiraIssueRequest = new JiraIssueRequest(jiraIssueRequestModel);
+            return Http.post(url, user, jiraIssueRequest) as unknown as Promise<ApiResponse>;
+        }
     }
 }
 

--- a/source/api/integrations_api.ts
+++ b/source/api/integrations_api.ts
@@ -25,6 +25,7 @@ import {ReviztoIssueFields} from "../models/api/integrations/revizto/api_issue_f
 import {JiraIssueRequest} from "../models/api/integrations/jira/JiraIssueRequest";
 import {ApiResponse} from "../models/api/integrations/jira/ApiResponse";
 import {JiraIssueRequestModel} from "../models/api/integrations/jira/JiraIssueRequestModel";
+import {FieldsConfiguration} from "../models/api/integrations/jira/FieldsConfiguration";
 
 export default class IntegrationsApi {
 
@@ -385,6 +386,11 @@ export default class IntegrationsApi {
             const jiraIssueRequest = new JiraIssueRequest(jiraIssueRequestModel);
             return Http.post(url, user, jiraIssueRequest) as unknown as Promise<ApiResponse>;
         }
+    }
+
+    static getJiraFieldsConfiguration(user: User): Promise<FieldsConfiguration> {
+        const url = `${Http.baseUrl()}/integrations/jira/configuration`;
+        return Http.get(url, user) as unknown as Promise<FieldsConfiguration>;
     }
 }
 

--- a/source/models/api/integrations/jira/ApiResponse.ts
+++ b/source/models/api/integrations/jira/ApiResponse.ts
@@ -1,0 +1,5 @@
+import {ApiResult} from "./ApiResult";
+
+export  class ApiResponse {
+    apiResults?: ApiResult[]
+}

--- a/source/models/api/integrations/jira/ApiResult.ts
+++ b/source/models/api/integrations/jira/ApiResult.ts
@@ -1,0 +1,4 @@
+export class ApiResult {
+    status?: number;
+    body?: string;
+}

--- a/source/models/api/integrations/jira/FieldsConfiguration.ts
+++ b/source/models/api/integrations/jira/FieldsConfiguration.ts
@@ -1,0 +1,7 @@
+import {JiraFieldProperty} from "./JiraFieldProperty";
+
+export class FieldsConfiguration {
+    buildingTypes?: JiraFieldProperty[];
+    priorityTypes?: JiraFieldProperty[];
+    requestTypes?: JiraFieldProperty[];
+}

--- a/source/models/api/integrations/jira/JiraFieldProperty.ts
+++ b/source/models/api/integrations/jira/JiraFieldProperty.ts
@@ -1,0 +1,4 @@
+export class JiraFieldProperty {
+    id: number;
+    name: string;
+}

--- a/source/models/api/integrations/jira/JiraIssueRequest.ts
+++ b/source/models/api/integrations/jira/JiraIssueRequest.ts
@@ -1,0 +1,17 @@
+import {RequestFieldValues} from "./RequestFieldValues";
+import {JiraIssueRequestModel} from "./JiraIssueRequestModel";
+
+export class JiraIssueRequest {
+    constructor(jiraIssueRequestModel: JiraIssueRequestModel) {
+        this.serviceDeskId = jiraIssueRequestModel?.serviceDeskId;
+        this.requestParticipants = jiraIssueRequestModel?.requestParticipants;
+        this.raiseOnBehalfOf = jiraIssueRequestModel?.raiseOnBehalfOf;
+        this.requestTypeIds = jiraIssueRequestModel?.requestTypeIds?.map((requestTypeId: number) => requestTypeId?.toString());
+        this.requestFieldValues = new RequestFieldValues(jiraIssueRequestModel);
+    }
+    serviceDeskId?: number;
+    requestTypeIds?: string[];
+    raiseOnBehalfOf?: string;
+    requestParticipants?: string[];
+    requestFieldValues?: RequestFieldValues;
+}

--- a/source/models/api/integrations/jira/JiraIssueRequestModel.ts
+++ b/source/models/api/integrations/jira/JiraIssueRequestModel.ts
@@ -1,0 +1,41 @@
+import { Moment } from "moment/moment";
+
+export class JiraIssueRequestModel {
+    serviceDeskId?: number;
+    requestTypeIds?: number[];
+    raiseOnBehalfOf?: string;
+    requestParticipants?: string[];
+    summary?: string;
+    projectName?: string;
+    projectLink?: string;
+    captureDate?: Moment;
+    subTaskNameTemplate?: string;
+    numberOfAreasOrLevels?: number;
+    totalProjectSquareFootage?: number;
+    spreadSheetLink?: string;
+    squareFootage?: number;
+    dateReceived?: Moment;
+    dueDate?: Moment;
+    buildingType?: string;
+    priority: string;
+
+    constructor(jiraTicketModel: JiraIssueRequestModel) {
+        this.serviceDeskId = jiraTicketModel.serviceDeskId;
+        this.requestTypeIds = jiraTicketModel.requestTypeIds;
+        this.requestParticipants = jiraTicketModel?.requestParticipants;
+        this.raiseOnBehalfOf = jiraTicketModel?.raiseOnBehalfOf;
+        this.dateReceived = jiraTicketModel.dateReceived;
+        this.buildingType = jiraTicketModel.buildingType;
+        this.summary = jiraTicketModel.summary;
+        this.projectLink = jiraTicketModel.projectLink;
+        this.projectName = jiraTicketModel.projectName;
+        this.captureDate = jiraTicketModel.captureDate;
+        this.subTaskNameTemplate = jiraTicketModel.subTaskNameTemplate;
+        this.numberOfAreasOrLevels = jiraTicketModel.numberOfAreasOrLevels;
+        this.totalProjectSquareFootage = jiraTicketModel.totalProjectSquareFootage;
+        this.spreadSheetLink = jiraTicketModel.spreadSheetLink;
+        this.squareFootage = jiraTicketModel.squareFootage;
+        this.dueDate = jiraTicketModel.dueDate;
+        this.priority = jiraTicketModel.priority;
+    }
+}

--- a/source/models/api/integrations/jira/RequestFieldValues.ts
+++ b/source/models/api/integrations/jira/RequestFieldValues.ts
@@ -1,0 +1,44 @@
+import {JiraIssueRequestModel} from "./JiraIssueRequestModel";
+
+export class RequestFieldValues {
+    constructor(jiraIssueRequestModel: JiraIssueRequestModel) {
+        this.dateReceived = this.formatDateToYyyyMmDd(jiraIssueRequestModel?.dateReceived);
+        this.buildingType = jiraIssueRequestModel?.buildingType;
+        this.summary = jiraIssueRequestModel?.summary;
+        this.projectLink = jiraIssueRequestModel?.projectLink;
+        this.projectName = jiraIssueRequestModel?.projectName;
+        this.captureDate = this.formatDateToYyyyMmDd(jiraIssueRequestModel?.captureDate);
+        this.subTaskNameTemplate = jiraIssueRequestModel?.subTaskNameTemplate;
+        this.numberOfAreasOrLevels = jiraIssueRequestModel?.numberOfAreasOrLevels;
+        this.totalProjectSquareFootage = jiraIssueRequestModel?.totalProjectSquareFootage;
+        this.spreadSheetLink = jiraIssueRequestModel?.spreadSheetLink;
+        this.squareFootage = jiraIssueRequestModel?.squareFootage;
+        this.dueDate = this.formatDateToYyyyMmDd(jiraIssueRequestModel?.dueDate);
+        this.priority = jiraIssueRequestModel?.priority ? jiraIssueRequestModel?.priority : "Unprioritized";
+    }
+    summary?: string;
+    projectName?: string;
+    projectLink?: string;
+    captureDate?: string;
+    subTaskNameTemplate?: string;
+    numberOfAreasOrLevels?: number;
+    totalProjectSquareFootage?: number;
+    spreadSheetLink?: string;
+    squareFootage?: number;
+    dateReceived?: string;
+    dueDate?: string;
+    buildingType?: string;
+    priority: string;
+
+    private formatDateToYyyyMmDd(date: any) {
+        if (date) {
+            const selectedDate = new Date(date);
+            const yyyy = selectedDate.getFullYear();
+            const mm = String(selectedDate.getMonth() + 1).padStart(2, '0');
+            const dd = String(selectedDate.getDate()).padStart(2, '0');
+
+            return`${yyyy}-${mm}-${dd}`;
+        }
+        return date;
+    }
+}

--- a/source/models/api/integrations/jira/RequestFieldValues.ts
+++ b/source/models/api/integrations/jira/RequestFieldValues.ts
@@ -1,4 +1,5 @@
 import {JiraIssueRequestModel} from "./JiraIssueRequestModel";
+import {DateFormatter} from "../../../../converters";
 
 export class RequestFieldValues {
     constructor(jiraIssueRequestModel: JiraIssueRequestModel) {
@@ -33,11 +34,8 @@ export class RequestFieldValues {
     private formatDateToYyyyMmDd(date: any) {
         if (date) {
             const selectedDate = new Date(date);
-            const yyyy = selectedDate.getFullYear();
-            const mm = String(selectedDate.getMonth() + 1).padStart(2, '0');
-            const dd = String(selectedDate.getDate()).padStart(2, '0');
-
-            return`${yyyy}-${mm}-${dd}`;
+            const formattedDate = new DateFormatter("YYYY-MM-DD").formatLocal(selectedDate);
+            return formattedDate;
         }
         return date;
     }

--- a/tests/api/integrations_api_test.ts
+++ b/tests/api/integrations_api_test.ts
@@ -2144,6 +2144,29 @@ describe("IntegrationsApi", () => {
         });
     });
 
+    describe("::getJiraFieldsConfiguration", () => {
+        let user: User;
+
+        afterEach(() => {
+            fetchMock.restore();
+        });
+
+        it("makes a request to the gateway to fetch jira api fields configuration", () => {
+            user = {
+                authType: GATEWAY_JWT,
+                gatewayUser: { idToken: "some-token", role: UserRole.SUPERADMIN }
+            };
+            fetchMock.get(`${Http.baseUrl()}/integrations/jira/configuration`, 200);
+
+            IntegrationsApi.getJiraFieldsConfiguration(user);
+
+            expect(fetchMock.lastCall()[0]).to.eq(`${Http.baseUrl()}/integrations/jira/configuration`);
+            expect(fetchMock.lastOptions().headers["Accept"]).to.eq("application/json");
+            expect(fetchMock.lastOptions().headers["Authorization"]).to.eq("Bearer some-token");
+            expect(fetchMock.lastOptions().method).to.eq("GET");
+        });
+    });
+
     describe("::getAllCreatedIssuesForDeviatedElements", () => {
         beforeEach(() => {
             fetchMock.post(`${Http.baseUrl()}/integrations/tools/issues`,


### PR DESCRIPTION
It includes

- an endpoint method to create a jira service ticket `createJiraServiceDeskTicket` from CAP