### PR TITLE
Add AiAssisted master format codes hephaestus endpoints [CAP-811]

### DIFF
--- a/source/api/project_api.ts
+++ b/source/api/project_api.ts
@@ -88,6 +88,28 @@ export default class ProjectApi {
     let url = `${Http.baseUrl()}/projects/${projectId}/scanned-masterformat-progress`;
     return Http.get(url, user) as unknown as Promise<ApiMasterformatProgress[]>;
   }
+  
+  static uploadAiAssistedProgressMasterFormatScheduleTsv(projectId, tsvContent: string, isCorrectedTsvFile:string, user: User) {
+    let url = `${Http.baseUrl()}/projects/${projectId}/hephaestus`;
+
+    let multipartFormData = new FormData();
+    let file = new Blob([tsvContent], { type: "text/tab-separated-values" });
+    multipartFormData.append("tsvFile", file, "file.tsv");
+    multipartFormData.append("isCorrectedTsvFile", isCorrectedTsvFile);
+
+    return Http.fetch(url, {
+      method: "POST",
+      headers: {
+        ...getAuthorizationHeaders(user)
+      },
+      body: multipartFormData
+    }) as unknown as Promise<any>;
+  }
+
+  static DownloadAiAssistedMasterFormatScheduleTsv(projectId, user: User) {
+    let url = `${Http.baseUrl()}/projects/${projectId}/hephaestus`;
+    return Http.get(url, user) as unknown as Promise<any>;
+  }
 
   /**
    * @deprecated use getProjectMasterformatProgress

--- a/tests/api/project_api_test.ts
+++ b/tests/api/project_api_test.ts
@@ -475,6 +475,71 @@ describe("ProjectApi", () => {
     });
   });
 
+  describe("#uploadAiAssistedProgressMasterFormatScheduleTsv", () => {
+    beforeEach(() => {
+      fetchMock.post(`${Http.baseUrl()}/projects/some-project-id/hephaestus`, 200);
+    });
+
+    it("makes a request to the gateway api", () => {
+      ProjectApi.uploadAiAssistedProgressMasterFormatScheduleTsv("some-project-id", "col1\tcol2\nval1\tval2", "true", user);
+
+      const fetchCall = fetchMock.lastCall();
+      expect(fetchCall[0]).to.eq(`${Http.baseUrl()}/projects/some-project-id/hephaestus`);
+    });
+
+    it("includes the authorization headers and correct form data", () => {
+      ProjectApi.uploadAiAssistedProgressMasterFormatScheduleTsv("some-project-id", "col1\tcol2\nval1\tval2", "true", user);
+
+      const lastFetchOpts = fetchMock.lastOptions();
+      const body = lastFetchOpts.body as FormData;
+
+      expect(lastFetchOpts.headers).to.include.keys("firebaseIdToken");
+      expect(lastFetchOpts.headers.firebaseIdToken).to.eq("some-firebase.id.token");
+      expect(body.get("isCorrectedTsvFile")).to.eq("true");
+      expect(body.has("tsvFile")).to.eq(true);
+    });
+
+    it("rejects the promise when the call fails", () => {
+      fetchMock.post(`${Http.baseUrl()}/projects/some-project-id/hephaestus`, { status: 500, body: {} }, { overwriteRoutes: true });
+
+      let rejected = false;
+      return ProjectApi.uploadAiAssistedProgressMasterFormatScheduleTsv("some-project-id", "col1\tcol2\nval1\tval2", "true", user)
+          .catch(() => { rejected = true; })
+          .finally(() => {
+            expect(rejected).to.eq(true);
+          });
+    });
+  });
+
+  describe("#DownloadAiAssistedMasterFormatScheduleTsv", () => {
+    beforeEach(() => {
+      fetchMock.get(`${Http.baseUrl()}/projects/some-project-id/hephaestus`, 200);
+    });
+
+    it("makes a GET request to the correct endpoint", () => {
+      ProjectApi.DownloadAiAssistedMasterFormatScheduleTsv("some-project-id", user);
+      const fetchCall = fetchMock.lastCall();
+      expect(fetchCall[0]).to.eq(`${Http.baseUrl()}/projects/some-project-id/hephaestus`);
+    });
+
+    it("includes the authorization headers", () => {
+      ProjectApi.DownloadAiAssistedMasterFormatScheduleTsv("some-project-id", user);
+      const lastFetchOpts = fetchMock.lastOptions();
+      expect(lastFetchOpts.headers).to.include.keys("firebaseIdToken");
+      expect(lastFetchOpts.headers.firebaseIdToken).to.eq("some-firebase.id.token");
+    });
+
+    it("rejects the promise when the call fails", () => {
+      fetchMock.get(`${Http.baseUrl()}/projects/some-project-id/hephaestus`, { status: 500, body: {} }, { overwriteRoutes: true });
+      let rejected = false;
+      return ProjectApi.DownloadAiAssistedMasterFormatScheduleTsv("some-project-id", user)
+          .catch(() => { rejected = true; })
+          .finally(() => {
+            expect(rejected).to.eq(true);
+          });
+    });
+  });
+
   describe("#listProjectFloorFiles", () => {
     beforeEach(() => {
       fetchMock.get(`${Http.baseUrl()}/projects/some-project-id/floor-files`,


### PR DESCRIPTION
This PR includes 

Endpoint integrations to enable calling the AI-assisted Masterformat scheduled TSV files (Hephaestus) from the frontend.