### PR TITLE
Add Aiassisted master format codes hephaestus endpoints[CAP-811]

### DIFF
--- a/source/api/project_api.ts
+++ b/source/api/project_api.ts
@@ -108,7 +108,12 @@ export default class ProjectApi {
 
   static DownloadAiAssistedMasterFormatScheduleTsv(projectId, user: User) {
     let url = `${Http.baseUrl()}/projects/${projectId}/hephaestus`;
-    return Http.get(url, user) as unknown as Promise<Response>;
+    return (fetch(url, {
+      method: "GET",
+      headers: {
+        ...getAuthorizationHeaders(user)
+      },
+    })) as unknown as Promise<Response>
   }
 
   /**


### PR DESCRIPTION
This PR includes changes to the Hephaestus GET endpoint. When using http.get, it was causing an issue because it attempted to parse the response as JSON. However, in this case, we don’t need to parse the response — we need to download it directly as a TSV file.