### PR TITLE
Revizto Add Issuetype Field [HMA-1397]

### DIFF
--- a/source/models/api/integrations/revizto/api_issue_fields.ts
+++ b/source/models/api/integrations/revizto/api_issue_fields.ts
@@ -4,6 +4,7 @@ export class ReviztoIssueFields {
     dueDate: string;
     priority: string;
     status: string;
+    issueType: string;
     title: string;
     description: string;
     assignee: string;
@@ -16,6 +17,7 @@ export class ReviztoIssueFields {
                     dueDate,
                     priority,
                     status,
+                    issueType,
                     title,
                     description,
                     assignee,
@@ -27,6 +29,7 @@ export class ReviztoIssueFields {
         this.dueDate = dueDate;
         this.priority = priority;
         this.status = status;
+        this.issueType = issueType;
         this.title = title;
         this.description = description;
         this.assignee = assignee;

--- a/tests/api/integrations_api_test.ts
+++ b/tests/api/integrations_api_test.ts
@@ -2042,6 +2042,7 @@ describe("IntegrationsApi", () => {
                 dueDate: "2023-12-31",
                 priority: "High",
                 status: "Open",
+                issueType: "some-issue-type",
                 title: "Issue Title",
                 description: "Detailed description of the issue",
                 assignee: "assignee@example.com",


### PR DESCRIPTION
  **Summary**                                                                                                                                                                                          
                                                                                                                                                                                                   
  - Added issueType as a new field on the ReviztoIssueFields model, alongside the existing fields (priority, status, dueDate, etc.)                                                                
  - Updated the constructor to accept and assign issueType
  - Added issueType to the test fixture for the Revizto issue fields coverage in integrations_api_test.ts    