### PR TITLE
Add Get User Project List Endpoint [HMA-1446]

### DIFF
--- a/source/api/user_api.ts
+++ b/source/api/user_api.ts
@@ -5,7 +5,7 @@ import makeErrorsPretty from "../utilities/make_errors_pretty";
 import ApiInvitation from "../models/api/api_invitation";
 import ApiCreateInvitationForm from "../models/api/api_create_invitation_form";
 import ApiUserPermission from "../models/api/api_user_permission";
-import {ApiUserRole} from "../models";
+import {ApiUserRole, ApiUserProject} from "../models";
 
 export default class UserApi {
 
@@ -72,6 +72,11 @@ export default class UserApi {
   static updateUserRoles(userId: number, roles: ApiUserRole[], user: User): Promise<void> {
     const url = `${Http.baseUrl()}/users/accounts/${userId}/roles`;
     return Http.post(url, user, roles) as unknown as Promise<void>;
+  }
+
+  static listUserProjects(user: User): Promise<ApiUserProject[]> {
+    const url = `${Http.baseUrl()}/users/accounts/projects`;
+    return Http.get(url, user) as unknown as Promise<ApiUserProject[]>;
   }
 
 }

--- a/source/models/api/api_user_project.ts
+++ b/source/models/api/api_user_project.ts
@@ -1,0 +1,25 @@
+import type {UserRoleType} from "../enums";
+
+export class ApiUserProject {
+  projectId: number;
+  projectName: string;
+  role: UserRoleType;
+  organizationFirebaseId: string;
+  projectFirebaseId: string;
+
+  constructor({
+                projectId,
+                projectName,
+                role,
+                organizationFirebaseId,
+                projectFirebaseId
+              }: Partial<ApiUserProject> = {}) {
+    this.projectId = projectId;
+    this.projectName = projectName;
+    this.role = role;
+    this.organizationFirebaseId = organizationFirebaseId;
+    this.projectFirebaseId = projectFirebaseId;
+  }
+}
+
+export default ApiUserProject;

--- a/source/models/api/index.ts
+++ b/source/models/api/index.ts
@@ -69,4 +69,5 @@ export * from "./api_action_payload";
 export * from "./api_partial_progress_element";
 export * from "./api_masterformat_with_uniformat";
 export * from "./api_user_role";
+export * from "./api_user_project";
 export * from "./api_organization_member";

--- a/tests/api/user_api_test.ts
+++ b/tests/api/user_api_test.ts
@@ -8,6 +8,7 @@ import UserPermissionType from "../../source/models/enums/user_permission_type";
 import {
   ApiUser,
   ApiUserPermission,
+  ApiUserProject,
   ApiUserRole,
   FIREBASE,
   GATEWAY_JWT,
@@ -349,6 +350,63 @@ describe("UserApi", () => {
       });
 
       expect(fetchMock.lastOptions().headers.Authorization).to.eq("Bearer some-firebase.id.token");
+    });
+  });
+
+  describe("::listUserProjects", () => {
+    const userProjects: ApiUserProject[] = [
+      {
+        projectId: 260693,
+        projectName: "100RProjectPhotoIngestionTest",
+        role: UserRoleType.BASIC_USER,
+        organizationFirebaseId: "-ODfDtNSfRDr_8BbadPL",
+        projectFirebaseId: "-OezyB7xtOXhZG4JeFfk"
+      },
+      {
+        projectId: 260637,
+        projectName: "DemoProjectIngestion",
+        role: UserRoleType.BASIC_USER,
+        organizationFirebaseId: "-ODfDtNSfRDr_8BbadPL",
+        projectFirebaseId: "-Oew2AKX8vTGOGP_oDPy"
+      }
+    ];
+
+    beforeEach(() => {
+      fetchMock.get(`${Http.baseUrl()}/users/accounts/projects`,
+        {
+          status: 200,
+          body: userProjects
+        });
+    });
+
+    it("makes a call to the endpoint", () => {
+      UserApi.listUserProjects({
+        authType: GATEWAY_JWT,
+        gatewayUser: { idToken: "some-firebase.id.token", role: USER }
+      });
+
+      const fetchCall = fetchMock.lastCall();
+
+      expect(fetchCall[0]).to.eq(`${Http.baseUrl()}/users/accounts/projects`);
+      expect(fetchMock.lastOptions().headers.Accept).to.eq("application/json");
+    });
+
+    it("sends the request with an Authorization header", () => {
+      UserApi.listUserProjects({
+        authType: GATEWAY_JWT,
+        gatewayUser: { idToken: "some-firebase.id.token", role: USER }
+      });
+
+      expect(fetchMock.lastOptions().headers.Authorization).to.eq("Bearer some-firebase.id.token");
+    });
+
+    it("returns the list of user projects", () => {
+      return UserApi.listUserProjects({
+        authType: GATEWAY_JWT,
+        gatewayUser: { idToken: "some-firebase.id.token", role: USER }
+      }).then(result => {
+        expect(result).to.deep.eq(userProjects);
+      });
     });
   });
 });


### PR DESCRIPTION
## Summary
Adds client-side support for the new `GET /users/accounts/projects` endpoint,
which returns the list of projects the authenticated user has access to.

## Changes
- New model `ApiUserProject` with fields: `projectId`, `projectName`, `role`,
  `organizationFirebaseId`, `projectFirebaseId`
- New method `UserApi.listUserProjects(user)` — GET `/users/accounts/projects`
- Exported `ApiUserProject` from the models index
- Tests for the new method covering URL, Authorization header, and response shape