### PR TITLE
add removeOrganizationMember API method [HMA-1460]

### DIFF
--- a/source/api/organization_api.ts
+++ b/source/api/organization_api.ts
@@ -33,6 +33,11 @@ export default class OrganizationApi {
     return Http.get(url, user);
   }
 
+  static removeOrganizationMember(organizationId: string, userId: number, user: User): Promise<void> {
+    let url = `${Http.baseUrl()}/client-accounts/${organizationId}/members/${userId}`;
+    return Http.delete(url, user) as unknown as Promise<void>;
+  }
+
   static createOrganization(organization: ApiOrganization, user: User): Promise<{ firebaseId: string }> {
     let url = `${Http.baseUrl()}/client-accounts`;
     return Http.post(url, user, organization);

--- a/tests/api/organization_api_test.ts
+++ b/tests/api/organization_api_test.ts
@@ -17,6 +17,31 @@ describe("OrganizationApi", () => {
     };
   });
 
+  describe("#removeOrganizationMember", () => {
+    beforeEach(() => {
+      fetchMock.delete(`${Http.baseUrl()}/client-accounts/some-org-id/members/42`, {
+        status: 204,
+        body: null
+      });
+    });
+
+    it("makes a DELETE request to the correct URL", () => {
+      OrganizationApi.removeOrganizationMember("some-org-id", 42, user);
+      expect(fetchMock.lastCall()[0]).to.eq(`${Http.baseUrl()}/client-accounts/some-org-id/members/42`);
+    });
+
+    it("includes the user's auth token in the request", () => {
+      OrganizationApi.removeOrganizationMember("some-org-id", 42, user);
+      expect(fetchMock.lastOptions().headers.firebaseIdToken).to.eq("some-firebase.id.token");
+    });
+
+    it("returns a promise that resolves", () => {
+      return OrganizationApi.removeOrganizationMember("some-org-id", 42, user).then((result) => {
+        expect(result).to.be.empty;
+      });
+    });
+  });
+
   describe("#createOrganization", () => {
     beforeEach(() => {
       fetchMock.post(`${Http.baseUrl()}/client-accounts`, {


### PR DESCRIPTION
#### What changed

Added `removeOrganizationMember()` to `OrganizationApi` to call the new backend `DELETE /client-accounts/{organizationId}/members/{userId}` endpoint. This is the method the front-end action dispatches when a SuperAdmin removes a user from an organization.

```typescript
static removeOrganizationMember(
  organizationId: string,
  userId: number,
  user: User
): Promise<void>
```

Returns `Promise<void>` — the backend responds with 204 No Content.

#### Files changed

| File | Change |
|---|---|
| `source/api/organization_api.ts` | Added `removeOrganizationMember` static method |

#### Tests

- `organization_api_test.ts` — DELETE request sent to correct URL, auth token included, promise resolves on success