### PR TITLE
filter archived added as parameter in project api [HMA-1656]

### DIFF
--- a/source/api/project_api.ts
+++ b/source/api/project_api.ts
@@ -9,8 +9,9 @@ import type { AssociationIds, DateLike } from "type_aliases";
 import ApiMasterFormatWithUniformat from "../models/api/api_masterformat_with_uniformat";
 
 export default class ProjectApi {
-  static listProjectsForOrganization(organizationId: string, user: User): Promise<ApiProject[]> {
-    let url = `${Http.baseUrl()}/client-accounts/${organizationId}/projects`;
+  static listProjectsForOrganization(organizationId: string, user: User, filterArchived: boolean = false): Promise<ApiProject[]> {
+    const query = filterArchived ? "?filterArchived=true" : "";
+    let url = `${Http.baseUrl()}/client-accounts/${organizationId}/projects${query}`;
     return Http.get(url, user) as unknown as Promise<ApiProject[]>;
   }
 

--- a/tests/api/project_api_test.ts
+++ b/tests/api/project_api_test.ts
@@ -6,8 +6,8 @@ import {ApiMasterformat, ApiMasterformatProgress, ApiProjectCostAnalysisProgress
 import DateConverter from "../../source/converters/date_converter";
 import Http from "../../source/utilities/http";
 import ProjectApi from "../../source/api/project_api";
-import {FIREBASE, GATEWAY_JWT} from "../../source/models/enums/user_auth_type";
-import {SUPERADMIN} from "../../source/models/enums/user_role";
+import {FIREBASE, GATEWAY_JWT} from "../../source";
+import {SUPERADMIN} from "../../source";
 
 describe("ProjectApi", () => {
   let user;
@@ -30,6 +30,10 @@ describe("ProjectApi", () => {
           archivedAt: DateConverter.dateToInstant(moment("2019-04-01"))
         }]
       });
+      fetchMock.get(`${Http.baseUrl()}/client-accounts/some-organization-id/projects?filterArchived=true`, {
+        status: 200,
+        body: []
+      });
     });
 
     it("makes an authenticated call to the endpoint", () => {
@@ -41,6 +45,18 @@ describe("ProjectApi", () => {
       expect(fetchCall[0]).to.eq(`${Http.baseUrl()}/client-accounts/some-organization-id/projects`);
       expect(lastFetchOpts.headers).to.include.keys("firebaseIdToken");
       expect(lastFetchOpts.headers.firebaseIdToken).to.eq("some-firebase.id.token");
+    });
+
+    it("does not append filterArchived when false", () => {
+      ProjectApi.listProjectsForOrganization("some-organization-id", user, false);
+
+      expect(fetchMock.lastCall()[0]).to.eq(`${Http.baseUrl()}/client-accounts/some-organization-id/projects`);
+    });
+
+    it("appends filterArchived=true to the url when true", () => {
+      ProjectApi.listProjectsForOrganization("some-organization-id", user, true);
+
+      expect(fetchMock.lastCall()[0]).to.eq(`${Http.baseUrl()}/client-accounts/some-organization-id/projects?filterArchived=true`);
     });
   });
 


### PR DESCRIPTION
  - Adds an optional `filterArchived` boolean parameter to `ProjectApi.listProjectsForOrganization`, defaulting to `false` to preserve existing behavior.
  - When `true`, the client appends `?filterArchived=true` to the `/client-accounts/{organizationId}/projects` request so the gateway can omit archived projects
  from the response.
