### PR TITLE
Add CSS Lead Contact Endpoints [HMA-1573]

### DIFF
--- a/source/api/organization_api.ts
+++ b/source/api/organization_api.ts
@@ -6,6 +6,8 @@ import makeErrorsPretty from "../utilities/make_errors_pretty";
 import ApiUserForOrganization from "../models/api/api_user_for_organization";
 import { ApiScanDatasetStats } from "../models/api/api_scandataset_stats";
 import {ApiOrganizationMember} from "../models";
+import ApiCssEligibleUser from "../models/api/api_css_eligible_user";
+import ApiCssContact from "../models/api/api_css_contact";
 
 export default class OrganizationApi {
   static listOrganizations(user: User): Promise<ApiOrganization[]> {
@@ -51,6 +53,26 @@ export default class OrganizationApi {
   static getScanDataSetStats(user: User): Promise<ApiScanDatasetStats[]> {
     let url =  `${Http.baseUrl()}/client-accounts/scan-dataset-stats`;
     return Http.get(url, user) as unknown as Promise<ApiScanDatasetStats[]>;
+  }
+
+  static getCssEligibleUsers(organizationId: string, user: User): Promise<ApiCssEligibleUser[]> {
+    let url = `${Http.baseUrl()}/client-accounts/${organizationId}/css-eligible-users`;
+    return Http.get(url, user) as unknown as Promise<ApiCssEligibleUser[]>;
+  }
+
+  static listCssContacts(organizationId: string, user: User): Promise<ApiCssContact[]> {
+    let url = `${Http.baseUrl()}/client-accounts/${organizationId}/css-contacts`;
+    return Http.get(url, user) as unknown as Promise<ApiCssContact[]>;
+  }
+
+  static createCssContact(organizationId: string, userId: number, user: User): Promise<ApiCssContact> {
+    let url = `${Http.baseUrl()}/client-accounts/${organizationId}/css-contacts`;
+    return Http.post(url, user, { userId }) as unknown as Promise<ApiCssContact>;
+  }
+
+  static deleteCssContact(organizationId: string, contactId: number, user: User): Promise<void> {
+    let url = `${Http.baseUrl()}/client-accounts/${organizationId}/css-contacts/${contactId}`;
+    return Http.delete(url, user) as unknown as Promise<void>;
   }
 }
 

--- a/source/models/api/api_css_contact.ts
+++ b/source/models/api/api_css_contact.ts
@@ -1,0 +1,36 @@
+import { addInstantGetterAndSetterToApiModel } from "../../mixins";
+import type { DateLike, ModifyPartial } from "type_aliases";
+
+export type ApiCssContactArgument = ModifyPartial<ApiCssContact, {
+  createdAt: DateLike
+}>
+
+export class ApiCssContact {
+  id: number;
+  userId?: number;
+  email: string;
+  name: string;
+  organizationId?: number;
+  createdBy?: number;
+  createdAt: number;
+
+  constructor({
+    id,
+    userId,
+    email,
+    name,
+    organizationId,
+    createdBy,
+    createdAt
+  }: ApiCssContactArgument = {}) {
+    this.id = id;
+    this.userId = userId;
+    this.email = email;
+    this.name = name;
+    this.organizationId = organizationId;
+    this.createdBy = createdBy;
+    addInstantGetterAndSetterToApiModel(this, "createdAt", createdAt);
+  }
+}
+
+export default ApiCssContact;

--- a/source/models/api/api_css_eligible_user.ts
+++ b/source/models/api/api_css_eligible_user.ts
@@ -1,0 +1,13 @@
+export class ApiCssEligibleUser {
+  id: number;
+  email: string;
+  name: string;
+
+  constructor({ id, email, name }: Partial<ApiCssEligibleUser> = {}) {
+    this.id = id;
+    this.email = email;
+    this.name = name;
+  }
+}
+
+export default ApiCssEligibleUser;

--- a/source/models/api/index.ts
+++ b/source/models/api/index.ts
@@ -1,3 +1,5 @@
+export { ApiCssEligibleUser } from "./api_css_eligible_user";
+export { ApiCssContact, ApiCssContactArgument } from "./api_css_contact";
 export { ApiRpcSession } from "./api_rpc_session";
 export { ApiRpcQueryResponse } from "./api_rpc_query_response";
 export { ApiRpcQueryRequest } from "./api_rpc_query_request";


### PR DESCRIPTION
## Summary
Adds CSS (Customer Success) lead contact API endpoints to the JavaScript client SDK.

## Changes
- Add `ApiCssContact` model with fields: id, userId, email, name, organizationId, createdBy, createdAt
- Add `ApiCssEligibleUser` model with fields: id, email, name
- Add `OrganizationApi.getCssEligibleUsers()` — GET /client-accounts/{organizationId}/css-eligible-users
- Add `OrganizationApi.listCssContacts()` — GET /client-accounts/{organizationId}/css-contacts
- Add `OrganizationApi.createCssContact()` — POST /client-accounts/{organizationId}/css-contacts
- Add `OrganizationApi.deleteCssContact()` — DELETE /client-accounts/{organizationId}/css-contacts/{cssContactId}
- Export new models from `source/models/api/index.ts`

## Notes
CSS eligible users are superadmins within an organization. The `cssContactId` parameter in the delete endpoint refers to the contact record's `id` field.