### PR TITLE
add overall project deviation summary endpoint [HMA-1759]

### DIFF
--- a/source/api/project_api.ts
+++ b/source/api/project_api.ts
@@ -4,7 +4,7 @@ import makeErrorsPretty from "../utilities/make_errors_pretty";
 import { DateConverter } from "../converters";
 import { PbeTsvType } from "../models/api/pbe_tsv_type";
 
-import type { ApiClassificationCode, ApiCloudFile, ApiMasterformatProgress, ApiProject, ApiProjectCostAnalysisProgress, ApiProjectCostAnalysisProgressValidationResult, ApiProjectListing, ApiProjectWorkPackage, ApiProjectWorkPackageCost, ApiRunningProcess, ProgressType, ProjectWorkPackageType, User } from "../models";
+import type { ApiClassificationCode, ApiCloudFile, ApiMasterformatProgress, ApiProject, ApiProjectCostAnalysisProgress, ApiProjectCostAnalysisProgressValidationResult, ApiProjectDeviationSummary, ApiProjectListing, ApiProjectWorkPackage, ApiProjectWorkPackageCost, ApiRunningProcess, ProgressType, ProjectWorkPackageType, User } from "../models";
 import type { AssociationIds, DateLike } from "type_aliases";
 import ApiMasterFormatWithUniformat from "../models/api/api_masterformat_with_uniformat";
 
@@ -36,6 +36,11 @@ export default class ProjectApi {
   static getProject(projectId: string, user: User): Promise<ApiProject> {
     let url = `${Http.baseUrl()}/projects/${projectId}`;
     return Http.get(url, user) as unknown as Promise<ApiProject>;
+  }
+
+  static getProjectDeviationSummary({ projectId }: AssociationIds, user: User): Promise<ApiProjectDeviationSummary> {
+    let url = `${Http.baseUrl()}/projects/${projectId}/deviation-summary`;
+    return Http.get(url, user) as unknown as Promise<ApiProjectDeviationSummary>;
   }
 
   static createProject(organizationId: string, project: ApiProject, user: User): Promise<{ firebaseId: string }> {

--- a/source/models/api/api_project_deviation_summary.ts
+++ b/source/models/api/api_project_deviation_summary.ts
@@ -1,0 +1,8 @@
+export class ApiProjectDeviationSummary {
+  inPlace: number;
+  deviatedWithinTolerance: number;
+  criticallyDeviated: number;
+  notBuilt: number;
+}
+
+export default ApiProjectDeviationSummary;

--- a/source/models/api/index.ts
+++ b/source/models/api/index.ts
@@ -44,6 +44,7 @@ export * from "./api_project_work_package_cost";
 export * from "./api_project_work_package";
 export * from "./api_project_summary";
 export * from "./api_project_settings";
+export * from "./api_project_deviation_summary";
 export * from "./api_project_report_version";
 export * from "./api_project_report";
 export * from "./api_project_area_work_package";

--- a/tests/api/project_api_test.ts
+++ b/tests/api/project_api_test.ts
@@ -86,6 +86,40 @@ describe("ProjectApi", () => {
     });
   });
 
+  describe("#getProjectDeviationSummary", () => {
+    beforeEach(() => {
+      fetchMock.get(`${Http.baseUrl()}/projects/some-project-id/deviation-summary`, {
+        status: 200,
+        body: {
+          inPlace: 0.25,
+          deviatedWithinTolerance: 0.25,
+          criticallyDeviated: 0.25,
+          notBuilt: 0.25
+        }
+      });
+    });
+
+    it("makes a request to the gateway api", () => {
+      ProjectApi.getProjectDeviationSummary({ projectId: "some-project-id" }, {
+        authType: "GATEWAY_JWT",
+        gatewayUser: { idToken: "some-firebase.id.token" }
+      });
+      const fetchCall = fetchMock.lastCall();
+
+      expect(fetchCall[0]).to.eq(`${Http.baseUrl()}/projects/some-project-id/deviation-summary`);
+      expect(fetchMock.lastOptions().headers.Accept).to.eq("application/json");
+    });
+
+    it("includes the authorization headers", () => {
+      ProjectApi.getProjectDeviationSummary({ projectId: "some-project-id" }, {
+        authType: "GATEWAY_JWT",
+        gatewayUser: { idToken: "some-firebase.id.token" }
+      });
+
+      expect(fetchMock.lastOptions().headers.Authorization).to.eq("Bearer some-firebase.id.token");
+    });
+  });
+
   describe("#updateProject", () => {
     beforeEach(() => {
       fetchMock.patch(`${Http.baseUrl()}/projects/some-project-id`, 200);


### PR DESCRIPTION
### Summary
Adds the client binding for the new gateway endpoint `GET /projects/{projectId}/deviation-summary`, so avvir-web can fetch overall project deviation for the dashboard's deviation donut.
 
### Changes
- `models/api/api_project_deviation_summary.ts` — new model `ApiProjectDeviationSummary { inPlace, deviatedWithinTolerance, criticallyDeviated, notBuilt: number }`
- `models/api/index.ts` — exports the new model
- `api/project_api.ts` — adds `getProjectDeviationSummary({ projectId }, user): Promise<ApiProjectDeviationSummary>` via `Http.get`
- `tests/api/project_api_test.ts` — adds `#getProjectDeviationSummary` tests (fetch-mock)