### PR TITLE
add getProjectProgressSummary API method [HMA-1758]

### DIFF
--- a/source/api/project_api.ts
+++ b/source/api/project_api.ts
@@ -4,7 +4,7 @@ import makeErrorsPretty from "../utilities/make_errors_pretty";
 import { DateConverter } from "../converters";
 import { PbeTsvType } from "../models/api/pbe_tsv_type";
 
-import type { ApiClassificationCode, ApiCloudFile, ApiMasterformatProgress, ApiProject, ApiProjectCostAnalysisProgress, ApiProjectCostAnalysisProgressValidationResult, ApiProjectDeviationSummary, ApiProjectListing, ApiProjectWorkPackage, ApiProjectWorkPackageCost, ApiRunningProcess, ProgressType, ProjectWorkPackageType, User } from "../models";
+import type { ApiClassificationCode, ApiCloudFile, ApiMasterformatProgress, ApiProject, ApiProjectCostAnalysisProgress, ApiProjectCostAnalysisProgressValidationResult, ApiProjectDeviationSummary, ApiProjectListing, ApiProjectProgressSummary, ApiProjectWorkPackage, ApiProjectWorkPackageCost, ApiRunningProcess, ProgressType, ProjectWorkPackageType, User } from "../models";
 import type { AssociationIds, DateLike } from "type_aliases";
 import ApiMasterFormatWithUniformat from "../models/api/api_masterformat_with_uniformat";
 
@@ -41,6 +41,11 @@ export default class ProjectApi {
   static getProjectDeviationSummary({ projectId }: AssociationIds, user: User): Promise<ApiProjectDeviationSummary> {
     let url = `${Http.baseUrl()}/projects/${projectId}/deviation-summary`;
     return Http.get(url, user) as unknown as Promise<ApiProjectDeviationSummary>;
+  }
+
+  static getProjectProgressSummary({ projectId }: AssociationIds, user: User): Promise<ApiProjectProgressSummary> {
+    let url = `${Http.baseUrl()}/projects/${projectId}/progress-summary`;
+    return Http.get(url, user) as unknown as Promise<ApiProjectProgressSummary>;
   }
 
   static createProject(organizationId: string, project: ApiProject, user: User): Promise<{ firebaseId: string }> {

--- a/source/models/api/api_project_progress_summary.ts
+++ b/source/models/api/api_project_progress_summary.ts
@@ -1,0 +1,5 @@
+export class ApiProjectProgressSummary {
+  built: number;
+}
+
+export default ApiProjectProgressSummary;

--- a/source/models/api/index.ts
+++ b/source/models/api/index.ts
@@ -45,6 +45,7 @@ export * from "./api_project_work_package";
 export * from "./api_project_summary";
 export * from "./api_project_settings";
 export * from "./api_project_deviation_summary";
+export * from "./api_project_progress_summary";
 export * from "./api_project_report_version";
 export * from "./api_project_report";
 export * from "./api_project_area_work_package";

--- a/tests/api/project_api_test.ts
+++ b/tests/api/project_api_test.ts
@@ -120,6 +120,35 @@ describe("ProjectApi", () => {
     });
   });
 
+  describe("#getProjectProgressSummary", () => {
+    beforeEach(() => {
+      fetchMock.get(`${Http.baseUrl()}/projects/some-project-id/progress-summary`, {
+        status: 200,
+        body: { built: 0.3 }
+      });
+    });
+
+    it("makes a request to the gateway api", () => {
+      ProjectApi.getProjectProgressSummary({ projectId: "some-project-id" }, {
+        authType: "GATEWAY_JWT",
+        gatewayUser: { idToken: "some-firebase.id.token" }
+      });
+      const fetchCall = fetchMock.lastCall();
+
+      expect(fetchCall[0]).to.eq(`${Http.baseUrl()}/projects/some-project-id/progress-summary`);
+      expect(fetchMock.lastOptions().headers.Accept).to.eq("application/json");
+    });
+
+    it("includes the authorization headers", () => {
+      ProjectApi.getProjectProgressSummary({ projectId: "some-project-id" }, {
+        authType: "GATEWAY_JWT",
+        gatewayUser: { idToken: "some-firebase.id.token" }
+      });
+
+      expect(fetchMock.lastOptions().headers.Authorization).to.eq("Bearer some-firebase.id.token");
+    });
+  });
+
   describe("#updateProject", () => {
     beforeEach(() => {
       fetchMock.patch(`${Http.baseUrl()}/projects/some-project-id`, 200);


### PR DESCRIPTION
## Summary
 
Adds the client method and model for the new gateway project progress-summary endpoint, consumed by the avvir-web dashboard "Overall Project Progress" donut.
 
## Changes
 
- `ApiProjectProgressSummary { built: number }` model plus barrel export from `models/api`.
- `ProjectApi.getProjectProgressSummary({ projectId }, user)` calling `GET /projects/{projectId}/progress-summary`.
- `index.ts` - export `api_project_progress_summary`
- `project_api_test` — asserts the method hits `/projects/{projectId}/progress-summary` and sends the authorization headers.