### PR TITLE
add "last updated" date fields to project summary donut chart models [HMA-1711]

### DIFF
--- a/source/models/api/api_project_deviation_summary.ts
+++ b/source/models/api/api_project_deviation_summary.ts
@@ -3,6 +3,12 @@ export class ApiProjectDeviationSummary {
   deviatedWithinTolerance: number;
   criticallyDeviated: number;
   notBuilt: number;
+  latestBuiltAt: number | null;
+  latestFixedAt: number | null;
+  latestScanDate: number | null;
+  latestAnalysisCompletedAt: number | null;
+  latestDeviationChangedAt: number | null;
+  latestUpdatedAt: number | null;
 }
 
 export default ApiProjectDeviationSummary;

--- a/source/models/api/api_project_progress_summary.ts
+++ b/source/models/api/api_project_progress_summary.ts
@@ -1,5 +1,11 @@
 export class ApiProjectProgressSummary {
   built: number;
+  latestBuiltAt: number | null;
+  latestFixedAt: number | null;
+  latestScanDate: number | null;
+  latestAnalysisCompletedAt: number | null;
+  latestDeviationChangedAt: number | null;
+  latestUpdatedAt: number | null;
 }
 
 export default ApiProjectProgressSummary;


### PR DESCRIPTION
## Summary
 
Adds the date fields now returned by the updated gateway `progress-summary` and `deviation-summary` endpoints to their client models, so avvir-web can read them type-safely for the dashboard donut "last updated" footers. Additive; no API-method or signature changes.
 
## Changes
 
- `ApiProjectProgressSummary` — adds `latestBuiltAt`, `latestFixedAt`, `latestScanDate`, `latestAnalysisCompletedAt`, `latestDeviationChangedAt`, `latestUpdatedAt`, all `number | null`, alongside the existing `built`.
- `ApiProjectDeviationSummary` — adds the same six `number | null` fields alongside the existing `inPlace` / `deviatedWithinTolerance` / `criticallyDeviated` / `notBuilt` buckets.
- Values are epoch-seconds instants (the gateway serializes `Instant` as seconds), consistent with the rest of the avvir models and `DateConverter.instantToDate`.