### PR TITLE
add getProjectSupportingSignals API method [HMA-1753]

### DIFF
--- a/source/api/project_summary_api.ts
+++ b/source/api/project_summary_api.ts
@@ -1,10 +1,14 @@
 import makeErrorsPretty from "../utilities/make_errors_pretty";
-import { ApiProjectArea, ApiProjectAreaWorkPackage, ApiProjectSummary, User } from "../models";
+import { ApiProjectArea, ApiProjectAreaWorkPackage, ApiProjectSummary, ApiProjectSupportingSignals, User } from "../models";
 import Http from "../utilities/http";
 
 export default class ProjectSummaryApi {
     static getProjectSummary(projectId: string, user: User) {
         return Http.get(`${Http.baseUrl()}/projects/${projectId}/summary`, user) as unknown as Promise<ApiProjectSummary>;
+    }
+
+    static getProjectSupportingSignals(projectId: string, user: User) {
+        return Http.get(`${Http.baseUrl()}/projects/${projectId}/supporting-signals`, user) as unknown as Promise<ApiProjectSupportingSignals>;
     }
 
     /**

--- a/source/models/api/api_project_supporting_signals.ts
+++ b/source/models/api/api_project_supporting_signals.ts
@@ -1,0 +1,5 @@
+export interface ApiProjectSupportingSignals {
+  latestBimUploadDate: string | null;
+  latestScanDate: string | null;
+  latestPhotoDate: string | null;
+}

--- a/source/models/api/index.ts
+++ b/source/models/api/index.ts
@@ -43,6 +43,7 @@ export * from "../enums/api_purpose_type";
 export * from "./api_project_work_package_cost";
 export * from "./api_project_work_package";
 export * from "./api_project_summary";
+export * from "./api_project_supporting_signals";
 export * from "./api_project_settings";
 export * from "./api_project_deviation_summary";
 export * from "./api_project_progress_summary";

--- a/tests/api/project_summary_api_test.ts
+++ b/tests/api/project_summary_api_test.ts
@@ -46,6 +46,33 @@ describe("ProjectSummaryApi", () => {
     });
   });
 
+  describe("::getProjectSupportingSignals", () => {
+    beforeEach(() => {
+
+      fetchMock.get(`${Http.baseUrl()}/projects/some-project-id/supporting-signals`, 200);
+    });
+
+    it("makes a request to the gateway api", () => {
+      ProjectSummaryApi.getProjectSupportingSignals("some-project-id", {
+        authType: "GATEWAY_JWT",
+        gatewayUser: { idToken: "some-firebase.id.token" }
+      } as User);
+      const fetchCall = fetchMock.lastCall();
+
+      expect(fetchCall[0]).to.eq(`${Http.baseUrl()}/projects/some-project-id/supporting-signals`);
+      expect(fetchMock.lastOptions().headers.Accept).to.eq("application/json");
+    });
+
+    it("includes the authorization headers", () => {
+      ProjectSummaryApi.getProjectSupportingSignals("some-project-id", {
+        authType: "GATEWAY_JWT",
+        gatewayUser: { idToken: "some-firebase.id.token" }
+      } as User);
+
+      expect(fetchMock.lastOptions().headers.Authorization).to.eq("Bearer some-firebase.id.token");
+    });
+  });
+
   describe("::createProjectArea", () => {
     beforeEach(() => {
       fetchMock.post(`${Http.baseUrl()}/projects/some-project-id/areas`, new ApiProjectArea({


### PR DESCRIPTION
  ## Summary                                                                                                                                                                       
  Adds a `getProjectSupportingSignals` method to `ProjectSummaryApi` that fetches                                                                                                  
  the latest supporting-signal dates for a project from the gateway                                                                                                                
  (`GET /projects/{projectId}/supporting-signals`).                                                                                                                                
                                                                                                                                                                                   
  ## Changes                                                                                                                                                                       
  - Add `ProjectSummaryApi.getProjectSupportingSignals(projectId, user)` returning                                                                                                 
    `Promise<ApiProjectSupportingSignals>`.                                                                                                                                        
  - Add the `ApiProjectSupportingSignals` model interface with                                                                                                                     
    `latestBimUploadDate`, `latestScanDate`, and `latestPhotoDate`.                                                                                         
  - Re-export the new model from `models/api/index.ts`.      