### PR TITLE
support center — client api methods for project/org scope [HMA-1710]

### DIFF
--- a/source/api/organization_api.ts
+++ b/source/api/organization_api.ts
@@ -1,6 +1,6 @@
 // @ts-nocheck
 import ApiOrganization from "../models/api/api_organization";
-import { User } from "../utilities/get_authorization_headers";
+import getAuthorizationHeaders, { User } from "../utilities/get_authorization_headers";
 import Http from "../utilities/http";
 import makeErrorsPretty from "../utilities/make_errors_pretty";
 import ApiUserForOrganization from "../models/api/api_user_for_organization";
@@ -8,6 +8,8 @@ import { ApiScanDatasetStats } from "../models/api/api_scandataset_stats";
 import {ApiOrganizationMember} from "../models";
 import ApiCssEligibleUser from "../models/api/api_css_eligible_user";
 import ApiCssContact from "../models/api/api_css_contact";
+import ApiCssContactSummary from "../models/api/api_css_contact_summary";
+import ApiSupportRequest from "../models/api/api_support_request";
 
 export default class OrganizationApi {
   static listOrganizations(user: User): Promise<ApiOrganization[]> {
@@ -73,6 +75,34 @@ export default class OrganizationApi {
   static deleteCssContact(organizationId: string, contactId: number, user: User): Promise<void> {
     let url = `${Http.baseUrl()}/client-accounts/${organizationId}/css-contacts/${contactId}`;
     return Http.delete(url, user) as unknown as Promise<void>;
+  }
+
+  static getCssContactsForOrganization(organizationId: string, user: User): Promise<ApiCssContactSummary[]> {
+    let url = `${Http.baseUrl()}/support-center/css-contacts?organizationId=${encodeURIComponent(organizationId)}`;
+    return Http.get(url, user) as unknown as Promise<ApiCssContactSummary[]>;
+  }
+
+  static submitSupportRequestForOrganization(organizationId: string,
+                                             { description, sourcePage, files }: { description: string, sourcePage?: string, files?: File[] },
+                                             user: User): Promise<ApiSupportRequest> {
+    let url = `${Http.baseUrl()}/support-center/support-requests?organizationId=${encodeURIComponent(organizationId)}`;
+
+    let multipartFormData = new FormData();
+    multipartFormData.append("description", description);
+    if (sourcePage != null) {
+      multipartFormData.append("sourcePage", sourcePage);
+    }
+    (files || []).forEach((file) => {
+      multipartFormData.append("attachments", file, file.name);
+    });
+
+    return Http.fetch(url, {
+      method: "POST",
+      headers: {
+        ...getAuthorizationHeaders(user)
+      },
+      body: multipartFormData
+    }) as unknown as Promise<ApiSupportRequest>;
   }
 }
 

--- a/source/api/project_api.ts
+++ b/source/api/project_api.ts
@@ -136,14 +136,14 @@ export default class ProjectApi {
   }
 
   static getCssContactsForProject(projectId: string, user: User): Promise<ApiCssContactSummary[]> {
-    let url = `${Http.baseUrl()}/projects/${projectId}/css-contacts`;
+    let url = `${Http.baseUrl()}/support-center/css-contacts?projectId=${encodeURIComponent(projectId)}`;
     return Http.get(url, user) as unknown as Promise<ApiCssContactSummary[]>;
   }
 
   static submitSupportRequest(projectId: string,
                               { description, sourcePage, files }: { description: string, sourcePage?: string, files?: File[] },
                               user: User): Promise<ApiSupportRequest> {
-    let url = `${Http.baseUrl()}/projects/${projectId}/support-requests`;
+    let url = `${Http.baseUrl()}/support-center/support-requests?projectId=${encodeURIComponent(projectId)}`;
 
     let multipartFormData = new FormData();
     multipartFormData.append("description", description);

--- a/tests/api/organization_api_test.ts
+++ b/tests/api/organization_api_test.ts
@@ -63,4 +63,46 @@ describe("OrganizationApi", () => {
       expect(lastFetchOpts.headers.firebaseIdToken).to.eq("some-firebase.id.token");
     });
   });
+
+  describe("#getCssContactsForOrganization", () => {
+    beforeEach(() => {
+      fetchMock.get(`${Http.baseUrl()}/support-center/css-contacts?organizationId=some-org-id`, {
+        status: 200,
+        body: [{ name: "Some CS Lead", email: "some.cs.lead@example.com" }]
+      });
+    });
+
+    it("makes an authenticated call to the endpoint", () => {
+      OrganizationApi.getCssContactsForOrganization("some-org-id", user);
+
+      const fetchCall = fetchMock.lastCall();
+      expect(fetchCall[0]).to.eq(`${Http.baseUrl()}/support-center/css-contacts?organizationId=some-org-id`);
+      expect(fetchMock.lastOptions().headers.firebaseIdToken).to.eq("some-firebase.id.token");
+    });
+  });
+
+  describe("#submitSupportRequestForOrganization", () => {
+    beforeEach(() => {
+      fetchMock.post(`${Http.baseUrl()}/support-center/support-requests?organizationId=some-org-id`, {
+        status: 201,
+        body: { id: 100, createdAt: 1751414400 }
+      });
+    });
+
+    it("posts multipart form data to the endpoint with auth headers", () => {
+      OrganizationApi.submitSupportRequestForOrganization(
+        "some-org-id",
+        { description: "Something is broken", sourcePage: "/organizations/some-org-id/support-center" },
+        user
+      );
+
+      const fetchCall = fetchMock.lastCall();
+      const lastFetchOpts = fetchMock.lastOptions();
+
+      expect(fetchCall[0]).to.eq(`${Http.baseUrl()}/support-center/support-requests?organizationId=some-org-id`);
+      expect(lastFetchOpts.method).to.eq("POST");
+      expect(lastFetchOpts.body).to.be.instanceof(FormData);
+      expect(lastFetchOpts.headers).to.include.keys("firebaseIdToken");
+    });
+  });
 });

--- a/tests/api/project_api_test.ts
+++ b/tests/api/project_api_test.ts
@@ -88,9 +88,9 @@ describe("ProjectApi", () => {
 
   describe("#getCssContactsForProject", () => {
     beforeEach(() => {
-      fetchMock.get(`${Http.baseUrl()}/projects/some-project-id/css-contacts`, {
+      fetchMock.get(`${Http.baseUrl()}/support-center/css-contacts?projectId=some-project-id`, {
         status: 200,
-        body: [{ name: "Jordan Rivera", email: "jordan.rivera@hexagon.com" }]
+        body: [{ name: "Some CS Lead", email: "some.cs.lead@example.com" }]
       });
     });
 
@@ -98,14 +98,14 @@ describe("ProjectApi", () => {
       ProjectApi.getCssContactsForProject("some-project-id", user);
 
       const fetchCall = fetchMock.lastCall();
-      expect(fetchCall[0]).to.eq(`${Http.baseUrl()}/projects/some-project-id/css-contacts`);
+      expect(fetchCall[0]).to.eq(`${Http.baseUrl()}/support-center/css-contacts?projectId=some-project-id`);
       expect(fetchMock.lastOptions().headers.firebaseIdToken).to.eq("some-firebase.id.token");
     });
   });
 
   describe("#submitSupportRequest", () => {
     beforeEach(() => {
-      fetchMock.post(`${Http.baseUrl()}/projects/some-project-id/support-requests`, {
+      fetchMock.post(`${Http.baseUrl()}/support-center/support-requests?projectId=some-project-id`, {
         status: 201,
         body: { id: 100, createdAt: 1751414400 }
       });
@@ -121,7 +121,7 @@ describe("ProjectApi", () => {
       const fetchCall = fetchMock.lastCall();
       const lastFetchOpts = fetchMock.lastOptions();
 
-      expect(fetchCall[0]).to.eq(`${Http.baseUrl()}/projects/some-project-id/support-requests`);
+      expect(fetchCall[0]).to.eq(`${Http.baseUrl()}/support-center/support-requests?projectId=some-project-id`);
       expect(lastFetchOpts.method).to.eq("POST");
       expect(lastFetchOpts.body).to.be.instanceof(FormData);
       expect(lastFetchOpts.headers).to.include.keys("firebaseIdToken");


### PR DESCRIPTION
## Summary
 
`avvir-web` can now read the assigned CS leads and submit a support request for **either a project or an organization**. If the customer is in projects scope page, then project is considered, otherwise organization is considered.
 
## What changed
 
- **`source/api/project_api.ts`** — `getCssContactsForProject` and `submitSupportRequest` now call `/support-center/css-contacts?projectId=…` and `/support-center/support-requests?projectId=…`. Method **names and signatures are unchanged**, so existing `avvir-web` calls keep working — only the URL changed (non-breaking). Query params are wrapped with `encodeURIComponent`.
- **`source/api/organization_api.ts`** — added `getCssContactsForOrganization` and `submitSupportRequestForOrganization` (`?organizationId=…`). The submit mirrors the project multipart + auth-header (`getAuthorizationHeaders`, `Http.fetch`) flow exactly so the browser sets the multipart boundary.

[HMA-1710]: https://multivista.atlassian.net/browse/HMA-1710?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ