### PR TITLE
add dashboardProgress / dashboardDeviation to ApiProjectSettings to configure donut charts visibility in dashboard page [HMA-1723]

### DIFF
--- a/source/models/api/api_project_settings.ts
+++ b/source/models/api/api_project_settings.ts
@@ -11,6 +11,8 @@ export class ApiProjectSettings {
   tradeFilterForceUniformat: boolean;
   createScanDatasetsAutomatically: boolean;
   automaticPhotoIngestion: boolean;
+  dashboardProgress: boolean;
+  dashboardDeviation: boolean;
 }
 
 export default ApiProjectSettings;


### PR DESCRIPTION
- add `dashboardProgress: boolean` and `dashboardDeviation: boolean` to `ApiProjectSettings` to configure donut charts visibility in dashboard page from project's operations page