### PR TITLE
add minimal & optimized PBE API methods with tests [HMA-1871]

### DIFF
--- a/source/api/element_api.ts
+++ b/source/api/element_api.ts
@@ -2,7 +2,7 @@ import DeviationStatus from "../models/enums/deviation_status";
 import Http from "../utilities/http";
 import makeErrorsPretty from "../utilities/make_errors_pretty";
 
-import type { ApiBcfBuildingElement, ApiBuiltStatus, ApiDetailedElement, ApiPlannedElement, ApiQueryResource, ApiRunningProcess, ApiScannedElement, ApiUserAction } from "../models";
+import type { ApiBcfBuildingElement, ApiBuiltStatus, ApiDetailedElement, ApiMinimalPlannedBuildingElement, ApiPlannedElement, ApiQueryResource, ApiRunningProcess, ApiScannedElement, ApiUserAction } from "../models";
 import type { AssociationIds } from "type_aliases";
 import type { User } from "../utilities/get_authorization_headers";
 import {ApiPartialProgressElement} from "../models";
@@ -11,6 +11,18 @@ export default class ElementApi {
   static getPlannedBuildingElements({ projectId, floorId }: AssociationIds, user: User): Promise<ApiPlannedElement[]> {
     let url = `${Http.baseUrl()}/projects/${projectId}/floors/${floorId}/planned-building-elements`;
     return Http.get(url, user) as unknown as Promise<ApiDetailedElement[]>;
+  }
+
+  static getMinimalPlannedBuildingElements({ projectId, floorId }: AssociationIds, user: User): Promise<ApiMinimalPlannedBuildingElement[]> {
+    let url = `${Http.baseUrl()}/projects/${projectId}/floors/${floorId}/planned-building-elements/minimal`;
+    return Http.get(url, user) as unknown as Promise<ApiMinimalPlannedBuildingElement[]>;
+  }
+
+  // same shape as getPlannedBuildingElements, but deviation vectors are trimmed to
+  // INCLUDED-only server-side. getPlannedBuildingElements remains the fallback.
+  static getOptimizedPlannedBuildingElements({ projectId, floorId }: AssociationIds, user: User): Promise<ApiPlannedElement[]> {
+    let url = `${Http.baseUrl()}/projects/${projectId}/floors/${floorId}/planned-building-elements/optimized`;
+    return Http.get(url, user) as unknown as Promise<ApiPlannedElement[]>;
   }
 
   static updateDeviationStatus({ projectId, floorId, scanDatasetId }: AssociationIds,

--- a/source/models/api/api_minimal_planned_building_element.ts
+++ b/source/models/api/api_minimal_planned_building_element.ts
@@ -1,0 +1,8 @@
+import { ApiBuiltStatus } from "../enums";
+
+export interface ApiMinimalPlannedBuildingElement {
+  globalId: string;
+  builtStatus: ApiBuiltStatus;
+  trade?: string;
+  uniformat?: string;
+}

--- a/source/models/api/index.ts
+++ b/source/models/api/index.ts
@@ -78,3 +78,4 @@ export * from "./api_masterformat_with_uniformat";
 export * from "./api_user_role";
 export * from "./api_user_project";
 export * from "./api_organization_member";
+export * from "./api_minimal_planned_building_element";

--- a/tests/api/element_api_test.ts
+++ b/tests/api/element_api_test.ts
@@ -106,6 +106,156 @@ describe("ElementApi", () => {
     });
   });
 
+  describe("::getMinimalPlannedBuildingElements", () => {
+    beforeEach(() => {
+      fetchMock.get(`${Http.baseUrl()}/projects/some-project-id/floors/some-floor-id/planned-building-elements/minimal`,
+        [{
+          globalId: "some-element-id",
+          builtStatus: ApiBuiltStatus.DEVIATED,
+          trade: "some-trade",
+          uniformat: "A1010.10"
+        }]);
+    });
+
+    it("makes a request to the minimal planned building elements endpoint", () => {
+      ElementApi.getMinimalPlannedBuildingElements({
+        projectId: "some-project-id",
+        floorId: "some-floor-id"
+      }, {
+        authType: GATEWAY_JWT,
+        gatewayUser: { idToken: "some-firebase.id.token", role: USER }
+      });
+
+      const fetchCall = fetchMock.lastCall();
+      expect(fetchCall[0])
+        .to
+        .eq(`${Http.baseUrl()}/projects/some-project-id/floors/some-floor-id/planned-building-elements/minimal`);
+      expect(fetchMock.lastOptions().headers.Accept).to.eq("application/json");
+    });
+
+    it("returns the minimal element payload", () => {
+      return ElementApi.getMinimalPlannedBuildingElements({
+          projectId: "some-project-id",
+          floorId: "some-floor-id"
+        }, {
+          authType: GATEWAY_JWT,
+          gatewayUser: { idToken: "some-firebase.id.token", role: USER }
+        })
+        .then((minimalElements) => {
+          expect(minimalElements).to.deep.eq([{
+            globalId: "some-element-id",
+            builtStatus: DEVIATED,
+            trade: "some-trade",
+            uniformat: "A1010.10"
+          }]);
+        });
+    });
+
+    describe("when the user is signed in", () => {
+      let user;
+      beforeEach(() => {
+        user = {
+          authType: GATEWAY_JWT,
+          gatewayUser: { idToken: "some-firebase.id.token", role: USER }
+        };
+      });
+
+      it("authenticates the request", () => {
+        ElementApi.getMinimalPlannedBuildingElements({
+          projectId: "some-project-id",
+          floorId: "some-floor-id"
+        }, user);
+
+        const lastFetchOpts = fetchMock.lastOptions();
+        expect(lastFetchOpts.headers.Authorization).to.eq("Bearer some-firebase.id.token");
+      });
+    });
+  });
+
+  describe("::getOptimizedPlannedBuildingElements", () => {
+    beforeEach(() => {
+      fetchMock.get(`${Http.baseUrl()}/projects/some-project-id/floors/some-floor-id/planned-building-elements/optimized`,
+        [{
+          name: "Some Element Name",
+          globalId: "some-element-id",
+          uniformat: "A1010.10",
+          trade: "some-trade",
+          deviation: {
+            deviationMeters: 1.4142135623730951,
+            status: DeviationStatus.INCLUDED,
+            deviationVectorMeters: {
+              x: 1,
+              y: 1,
+              z: 0
+            }
+          }
+        }]);
+    });
+
+    it("makes a request to the optimized planned building elements endpoint", () => {
+      ElementApi.getOptimizedPlannedBuildingElements({
+        projectId: "some-project-id",
+        floorId: "some-floor-id"
+      }, {
+        authType: GATEWAY_JWT,
+        gatewayUser: { idToken: "some-firebase.id.token", role: USER }
+      });
+
+      const fetchCall = fetchMock.lastCall();
+      expect(fetchCall[0])
+        .to
+        .eq(`${Http.baseUrl()}/projects/some-project-id/floors/some-floor-id/planned-building-elements/optimized`);
+      expect(fetchMock.lastOptions().headers.Accept).to.eq("application/json");
+    });
+
+    it("returns the optimized element payload", () => {
+      return ElementApi.getOptimizedPlannedBuildingElements({
+          projectId: "some-project-id",
+          floorId: "some-floor-id"
+        }, {
+          authType: GATEWAY_JWT,
+          gatewayUser: { idToken: "some-firebase.id.token", role: USER }
+        })
+        .then((optimizedElements) => {
+          expect(optimizedElements).to.deep.eq([{
+            name: "Some Element Name",
+            globalId: "some-element-id",
+            uniformat: "A1010.10",
+            trade: "some-trade",
+            deviation: {
+              deviationMeters: Math.sqrt(2),
+              status: INCLUDED,
+              deviationVectorMeters: {
+                x: 1,
+                y: 1,
+                z: 0
+              }
+            }
+          }]);
+        });
+    });
+
+    describe("when the user is signed in", () => {
+      let user;
+      beforeEach(() => {
+        user = {
+          authType: GATEWAY_JWT,
+          gatewayUser: { idToken: "some-firebase.id.token", role: USER }
+        };
+      });
+
+      it("authenticates the request", () => {
+        ElementApi.getOptimizedPlannedBuildingElements({
+          projectId: "some-project-id",
+          floorId: "some-floor-id"
+        }, user);
+
+        const lastFetchOpts = fetchMock.lastOptions();
+        expect(lastFetchOpts.headers.Authorization).to.eq("Bearer some-firebase.id.token");
+      });
+    });
+  });
+
   describe("::updateDeviationStatus", () => {
     beforeEach(() => {
       fetchMock.patch(`${Http.baseUrl()}/projects/some-project-id/floors/some-floor-id/scan-datasets/some-scan-id/deviation-status`,


### PR DESCRIPTION
                                                                                                                                                       
  Adds client bindings for the two new gateway endpoints that shrink the planned-building-element (PBE) payload for large BIM models:                             
                                                                                                                                                                  
  - ElementApi.getMinimalPlannedBuildingElements(...) → GET .../planned-building-elements/minimal, returns ApiMinimalPlannedBuildingElement[]                     
  - ElementApi.getOptimizedPlannedBuildingElements(...) → GET .../planned-building-elements/optimized, returns ApiPlannedElement[]                                
                                                                                                                                                                  

- [ ] Why                                                                                                                                                    

  The full PBE list is expensive to load for large models. The gateway (already merged) now offers two slimmer variants:                                          
                                                                                                                                                                  
  - minimal — only globalId, builtStatus, trade, uniformat; enough for the initial viewer paint and the floor-wide trade filter (reachable in Visual Progress /   
  basicBim mode, which loads only this payload).                                                                                                                  
  - optimized — identical shape to the full list, but per-element deviation vectors are emitted server-side only for INCLUDED-status deviations. deviationMeters  
  (magnitude) and status are still present for every element, so tolerance filtering, sorting, and coloring are unaffected. getPlannedBuildingElements remains the
  fallback.   

  

- [ ] Changes                                                                                                                                                         

                                                                                                                                                                  
  - source/models/api/api_minimal_planned_building_element.ts — new ApiMinimalPlannedBuildingElement interface (globalId, builtStatus, optional trade, optional   
  uniformat).                                                                                                                                                     
  - source/models/api/index.ts — export the new model from the barrel.                                                                                            
  - source/api/element_api.ts — add the two new methods.                                                                                                          
  - tests/api/element_api_test.ts — unit tests for both methods (endpoint URL, Accept header, response deserialization, auth header).       