### PR TITLE
project level lock while bulk project import [HMA-1464]

### DIFF
--- a/source/models/api/api_project.ts
+++ b/source/models/api/api_project.ts
@@ -49,7 +49,8 @@ export class ApiProject {
                 integrationProjectId,
                 settings,
                 baselineScheduleDate,
-                currentScheduleDate
+                currentScheduleDate,
+                isLocked
               }: ApiProjectArgument = {})
   {
     addInstantGetterAndSetterToApiModel(this, "startDate", startDate);
@@ -85,6 +86,7 @@ export class ApiProject {
     this.settings = settings;
     this.baselineScheduleDate = baselineScheduleDate;
     this.currentScheduleDate = currentScheduleDate;
+    this.isLocked = isLocked;
   }
 
   readonly id: number;
@@ -119,6 +121,7 @@ export class ApiProject {
   settings?: ApiProjectSettings;
   baselineScheduleDate?: Date;
   currentScheduleDate?: Date;
+  isLocked: boolean;
 }
 
 export default ApiProject;

--- a/tests/models/api/api_project_test.ts
+++ b/tests/models/api/api_project_test.ts
@@ -1,0 +1,19 @@
+import {expect} from "chai";
+
+import ApiProject from "../../../source/models/api/api_project";
+
+describe("ApiProject", () => {
+  describe("isLocked", () => {
+    it("carries isLocked through the constructor", () => {
+      const apiProject = new ApiProject({isLocked: true});
+
+      expect(apiProject.isLocked).to.eq(true);
+    });
+
+    it("is undefined when not provided", () => {
+      const apiProject = new ApiProject({});
+
+      expect(apiProject.isLocked).to.be.undefined;
+    });
+  });
+});


### PR DESCRIPTION
# HMA-1464 — expose `isLocked` on `ApiProject`
 
The gateway will now return `isLocked` on a project ([HMA-1464](https://github.com/Avvir/avvir-web-gateway/pull/1438)), the same way it already does for floors. But our `ApiProject` constructor only reads a fixed list of fields, so it was silently dropping `isLocked`. This adds it, mirroring `ApiFloor`, so `avvir-web` can read a project's locked state — for the ops-page "locked" warning and disabling the import button.
 
## Changes
 
- `source/models/api/api_project.ts` — `isLocked` in the constructor destructure + assignment, and the `isLocked: boolean` field. Same shape as `ApiFloor`.
- `tests/models/api/api_project_test.ts` — checks the constructor carries `isLocked` through, and that it's undefined when not provided.
Backward-compatible: it's an added optional field, so nothing that constructs or reads `ApiProject` today breaks. Consumers pick it up when they bump the `avvir` version.

[HMA-1464]: https://multivista.atlassian.net/browse/HMA-1464?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ