### PR TITLE
add the client for creating ACS work items in the Jira Business space [HMA-1856]

### DIFF
--- a/source/api/integrations_api.ts
+++ b/source/api/integrations_api.ts
@@ -27,6 +27,9 @@ import {JiraIssueRequest} from "../models/api/integrations/jira/JiraIssueRequest
 import {ApiResponse} from "../models/api/integrations/jira/ApiResponse";
 import {JiraIssueRequestModel} from "../models/api/integrations/jira/JiraIssueRequestModel";
 import {FieldsConfiguration} from "../models/api/integrations/jira/FieldsConfiguration";
+import {JiraAcsWorkItemRequest} from "../models/api/integrations/jira/JiraAcsWorkItemRequest";
+import {JiraAcsWorkItemRequestModel} from "../models/api/integrations/jira/JiraAcsWorkItemRequestModel";
+import {JiraAcsFieldsConfiguration} from "../models/api/integrations/jira/JiraAcsFieldsConfiguration";
 import { PowerBIAccessTokenResponse } from "../models/api/integrations/powerbi/api_access_token";
 import { EmbedTokenResponse } from "../models/api/integrations/powerbi/api_embed_token_response";
 import {ApiCoordinationIssueRequest} from "../models/api/integrations/procore/api_coordination_issue_request";
@@ -536,6 +539,18 @@ export default class IntegrationsApi {
     static getJiraFieldsConfiguration(user: User): Promise<FieldsConfiguration> {
         const url = `${Http.baseUrl()}/integrations/jira/configuration`;
         return Http.get(url, user) as unknown as Promise<FieldsConfiguration>;
+    }
+
+    static createJiraAcsWorkItem(jiraAcsWorkItemRequestModel: JiraAcsWorkItemRequestModel,
+                                 user: User): Promise<ApiResponse> {
+        const url = `${Http.baseUrl()}/integrations/jira/acs/create-work-item`;
+        const jiraAcsWorkItemRequest = new JiraAcsWorkItemRequest(jiraAcsWorkItemRequestModel);
+        return Http.post(url, user, jiraAcsWorkItemRequest) as unknown as Promise<ApiResponse>;
+    }
+
+    static getJiraAcsWorkItemFieldsConfiguration(user: User): Promise<JiraAcsFieldsConfiguration> {
+        const url = `${Http.baseUrl()}/integrations/jira/acs/configuration`;
+        return Http.get(url, user) as unknown as Promise<JiraAcsFieldsConfiguration>;
     }
 }
 

--- a/source/models/api/integrations/jira/JiraAcsFieldsConfiguration.ts
+++ b/source/models/api/integrations/jira/JiraAcsFieldsConfiguration.ts
@@ -1,0 +1,12 @@
+import { JiraFieldProperty } from "./JiraFieldProperty";
+import { JiraFieldAssignee } from "./JiraFieldAssignee";
+
+export class JiraAcsFieldsConfiguration {
+    buildingTypes?: JiraFieldProperty[];
+    priorityTypes?: JiraFieldProperty[];
+    workItemTypes?: JiraFieldProperty[];
+
+    assignees?: JiraFieldAssignee[];
+}
+
+export default JiraAcsFieldsConfiguration;

--- a/source/models/api/integrations/jira/JiraAcsWorkItemRequest.ts
+++ b/source/models/api/integrations/jira/JiraAcsWorkItemRequest.ts
@@ -1,0 +1,56 @@
+import { JiraAcsWorkItemRequestModel } from "./JiraAcsWorkItemRequestModel";
+import { DateFormatter } from "../../../../converters";
+
+export class JiraAcsWorkItemRequest {
+    avvirProjectId: string;
+    workItemTypeIds?: number[];
+    summary?: string;
+    projectName?: string;
+    projectLink?: string;
+    subTaskNameTemplate?: string;
+    numberOfAreasOrLevels?: number;
+    totalProjectSquareFootage?: number;
+    dueDate?: string;
+    buildingType?: string;
+    priority?: string;
+    assigneeAccountId?: string;
+    spreadSheetLink?: string;
+    squareFootage?: number;
+    dateReceived?: string;
+    captureDate?: string;
+
+    constructor(jiraAcsWorkItemRequestModel: JiraAcsWorkItemRequestModel) {
+        this.avvirProjectId = jiraAcsWorkItemRequestModel?.avvirProjectId;
+        this.workItemTypeIds = jiraAcsWorkItemRequestModel?.workItemTypeIds;
+        this.summary = jiraAcsWorkItemRequestModel?.summary;
+        this.projectName = jiraAcsWorkItemRequestModel?.projectName;
+        this.projectLink = jiraAcsWorkItemRequestModel?.projectLink;
+        this.subTaskNameTemplate = jiraAcsWorkItemRequestModel?.subTaskNameTemplate;
+        this.numberOfAreasOrLevels = jiraAcsWorkItemRequestModel?.numberOfAreasOrLevels;
+        this.totalProjectSquareFootage = jiraAcsWorkItemRequestModel?.totalProjectSquareFootage;
+        this.dueDate = this.formatDateToYyyyMmDd(jiraAcsWorkItemRequestModel?.dueDate);
+        this.buildingType = this.asOptionId(jiraAcsWorkItemRequestModel?.buildingType);
+        this.priority = this.asOptionId(jiraAcsWorkItemRequestModel?.priority);
+        this.assigneeAccountId = jiraAcsWorkItemRequestModel?.assigneeAccountId;
+        this.spreadSheetLink = jiraAcsWorkItemRequestModel?.spreadSheetLink;
+        this.squareFootage = jiraAcsWorkItemRequestModel?.squareFootage;
+        this.dateReceived = this.formatDateToYyyyMmDd(jiraAcsWorkItemRequestModel?.dateReceived);
+        this.captureDate = this.formatDateToYyyyMmDd(jiraAcsWorkItemRequestModel?.captureDate);
+    }
+
+    private formatDateToYyyyMmDd(date: any) {
+        if (date) {
+            return new DateFormatter("YYYY-MM-DD").formatLocal(new Date(date));
+        }
+        return undefined;
+    }
+
+    private asOptionId(optionId?: number) {
+        if (optionId && optionId > 0) {
+            return optionId.toString();
+        }
+        return undefined;
+    }
+}
+
+export default JiraAcsWorkItemRequest;

--- a/source/models/api/integrations/jira/JiraAcsWorkItemRequestModel.ts
+++ b/source/models/api/integrations/jira/JiraAcsWorkItemRequestModel.ts
@@ -1,0 +1,46 @@
+import { Moment } from "moment/moment";
+
+export class JiraAcsWorkItemRequestModel {
+
+    avvirProjectId: string;
+    workItemTypeIds?: number[];
+    summary?: string;
+    projectName?: string;
+    projectLink?: string;
+    subTaskNameTemplate?: string;
+    numberOfAreasOrLevels?: number;
+    totalProjectSquareFootage?: number;
+    dueDate?: Moment;
+    buildingType?: number;
+    priority?: number;
+    assigneeAccountId?: string;
+
+    // Only on the CAP BIM Classification create screen.
+    spreadSheetLink?: string;
+    squareFootage?: number;
+    dateReceived?: Moment;
+
+    // Only on the CAP Phototagging and CAP Scan QAQC create screens.
+    captureDate?: Moment;
+
+    constructor(jiraAcsWorkItemRequestModel: JiraAcsWorkItemRequestModel) {
+        this.avvirProjectId = jiraAcsWorkItemRequestModel?.avvirProjectId;
+        this.workItemTypeIds = jiraAcsWorkItemRequestModel?.workItemTypeIds;
+        this.summary = jiraAcsWorkItemRequestModel?.summary;
+        this.projectName = jiraAcsWorkItemRequestModel?.projectName;
+        this.projectLink = jiraAcsWorkItemRequestModel?.projectLink;
+        this.subTaskNameTemplate = jiraAcsWorkItemRequestModel?.subTaskNameTemplate;
+        this.numberOfAreasOrLevels = jiraAcsWorkItemRequestModel?.numberOfAreasOrLevels;
+        this.totalProjectSquareFootage = jiraAcsWorkItemRequestModel?.totalProjectSquareFootage;
+        this.dueDate = jiraAcsWorkItemRequestModel?.dueDate;
+        this.buildingType = jiraAcsWorkItemRequestModel?.buildingType;
+        this.priority = jiraAcsWorkItemRequestModel?.priority;
+        this.assigneeAccountId = jiraAcsWorkItemRequestModel?.assigneeAccountId;
+        this.spreadSheetLink = jiraAcsWorkItemRequestModel?.spreadSheetLink;
+        this.squareFootage = jiraAcsWorkItemRequestModel?.squareFootage;
+        this.dateReceived = jiraAcsWorkItemRequestModel?.dateReceived;
+        this.captureDate = jiraAcsWorkItemRequestModel?.captureDate;
+    }
+}
+
+export default JiraAcsWorkItemRequestModel;

--- a/tests/api/integrations_api_test.ts
+++ b/tests/api/integrations_api_test.ts
@@ -20,6 +20,7 @@ import {AutodeskRequest} from "../../source/models/api/integrations/autodesk/api
 import AutodeskIssue from "../../source/models/api/integrations/autodesk/api_autodesk_issue";
 import {ReviztoIssueFields} from "../../source/models/api/integrations/revizto/api_issue_fields";
 import {JiraIssueRequestModel} from "../../source/models/api/integrations/jira/JiraIssueRequestModel";
+import {JiraAcsWorkItemRequestModel} from "../../source/models/api/integrations/jira/JiraAcsWorkItemRequestModel";
 import moment from "moment";
 
 
@@ -2489,6 +2490,162 @@ describe("IntegrationsApi", () => {
             IntegrationsApi.getJiraFieldsConfiguration(user);
 
             expect(fetchMock.lastCall()[0]).to.eq(`${Http.baseUrl()}/integrations/jira/configuration`);
+            expect(fetchMock.lastOptions().headers["Accept"]).to.eq("application/json");
+            expect(fetchMock.lastOptions().headers["Authorization"]).to.eq("Bearer some-token");
+            expect(fetchMock.lastOptions().method).to.eq("GET");
+        });
+    });
+
+    describe("::createJiraAcsWorkItem", () => {
+        let jiraAcsWorkItemRequestModel: JiraAcsWorkItemRequestModel;
+        let user: User;
+
+        beforeEach(() => {
+            user = {
+                authType: GATEWAY_JWT,
+                gatewayUser: { idToken: "some-token", role: UserRole.SUPERADMIN }
+            };
+
+            jiraAcsWorkItemRequestModel = {
+                avvirProjectId: "some-avvir-project-id",
+                workItemTypeIds: [10369, 10370],
+                summary: "Some ACS work item summary",
+                projectName: "some-project-name",
+                projectLink: "https://some-project-link.com",
+                subTaskNameTemplate: "some-sub-task-name-template",
+                numberOfAreasOrLevels: 2,
+                totalProjectSquareFootage: 200,
+                dueDate: moment("2025-09-12"),
+                buildingType: 11272,
+                priority: 10000,
+                assigneeAccountId: "some-assignee-account-id",
+                captureDate: moment("2025-09-15")
+            };
+
+            fetchMock.post(`${Http.baseUrl()}/integrations/jira/acs/create-work-item`, 201);
+        });
+
+        afterEach(() => {
+            fetchMock.restore();
+        });
+
+        it("makes a request to the gateway", () => {
+            IntegrationsApi.createJiraAcsWorkItem(jiraAcsWorkItemRequestModel, user);
+
+            expect(fetchMock.lastCall()[0]).to.eq(`${Http.baseUrl()}/integrations/jira/acs/create-work-item`);
+            expect(fetchMock.lastOptions().headers["Accept"]).to.eq("application/json");
+            expect(fetchMock.lastOptions().headers["Authorization"]).to.eq("Bearer some-token");
+            expect(fetchMock.lastOptions().method).to.eq("POST");
+        });
+
+        it("sends a flat body, with none of the service desk concepts", () => {
+            IntegrationsApi.createJiraAcsWorkItem(jiraAcsWorkItemRequestModel, user);
+
+            const body = JSON.parse(lastMockedFetchCall().body);
+            expect(body.requestFieldValues).to.eq(undefined);
+            expect(body.serviceDeskId).to.eq(undefined);
+            expect(body.raiseOnBehalfOf).to.eq(undefined);
+            expect(body.requestParticipants).to.eq(undefined);
+        });
+
+        it("sends the Avvir project id, which the gateway needs to trace a failure to a project", () => {
+            IntegrationsApi.createJiraAcsWorkItem(jiraAcsWorkItemRequestModel, user);
+
+            expect(JSON.parse(lastMockedFetchCall().body).avvirProjectId).to.eq("some-avvir-project-id");
+        });
+
+        it("sends the work item type ids as numbers, which is what the gateway takes", () => {
+            IntegrationsApi.createJiraAcsWorkItem(jiraAcsWorkItemRequestModel, user);
+
+            expect(JSON.parse(lastMockedFetchCall().body).workItemTypeIds).to.deep.eq([10369, 10370]);
+        });
+
+        it("sends the building type and priority as their ids, not their names", () => {
+            IntegrationsApi.createJiraAcsWorkItem(jiraAcsWorkItemRequestModel, user);
+
+            const body = JSON.parse(lastMockedFetchCall().body);
+            expect(body.buildingType).to.eq("11272");
+            expect(body.priority).to.eq("10000");
+        });
+
+        it("formats every date the way Jira reads them", () => {
+            jiraAcsWorkItemRequestModel.dateReceived = moment("2025-09-10");
+
+            IntegrationsApi.createJiraAcsWorkItem(jiraAcsWorkItemRequestModel, user);
+
+            const body = JSON.parse(lastMockedFetchCall().body);
+            expect(body.dueDate).to.eq("2025-09-12");
+            expect(body.captureDate).to.eq("2025-09-15");
+            expect(body.dateReceived).to.eq("2025-09-10");
+        });
+
+        it("omits the priority when none was chosen, so Jira applies its own default", () => {
+            jiraAcsWorkItemRequestModel.priority = undefined;
+
+            IntegrationsApi.createJiraAcsWorkItem(jiraAcsWorkItemRequestModel, user);
+
+            expect(JSON.parse(lastMockedFetchCall().body).priority).to.eq(undefined);
+        });
+
+        it("omits a date that was never picked rather than sending null", () => {
+            jiraAcsWorkItemRequestModel.dueDate = null;
+            jiraAcsWorkItemRequestModel.captureDate = undefined;
+
+            IntegrationsApi.createJiraAcsWorkItem(jiraAcsWorkItemRequestModel, user);
+
+            const body = JSON.parse(lastMockedFetchCall().body);
+            expect(body).to.not.have.property("dueDate");
+            expect(body).to.not.have.property("captureDate");
+        });
+
+        it("omits an unfilled dropdown rather than sending it as zero", () => {
+            jiraAcsWorkItemRequestModel.buildingType = 0;
+
+            IntegrationsApi.createJiraAcsWorkItem(jiraAcsWorkItemRequestModel, user);
+
+            expect(JSON.parse(lastMockedFetchCall().body).buildingType).to.eq(undefined);
+        });
+
+        it("omits the assignee when none was chosen", () => {
+            jiraAcsWorkItemRequestModel.assigneeAccountId = undefined;
+
+            IntegrationsApi.createJiraAcsWorkItem(jiraAcsWorkItemRequestModel, user);
+
+            expect(JSON.parse(lastMockedFetchCall().body).assigneeAccountId).to.eq(undefined);
+        });
+
+        it("sends the BIM Classification fields when they are given", () => {
+            jiraAcsWorkItemRequestModel.workItemTypeIds = [10337];
+            jiraAcsWorkItemRequestModel.spreadSheetLink = "https://some-spreadsheet-link.com";
+            jiraAcsWorkItemRequestModel.squareFootage = 500;
+            jiraAcsWorkItemRequestModel.dateReceived = moment("2025-09-10");
+
+            IntegrationsApi.createJiraAcsWorkItem(jiraAcsWorkItemRequestModel, user);
+
+            const body = JSON.parse(lastMockedFetchCall().body);
+            expect(body.spreadSheetLink).to.eq("https://some-spreadsheet-link.com");
+            expect(body.squareFootage).to.eq(500);
+            expect(body.dateReceived).to.eq("2025-09-10");
+        });
+    });
+
+    describe("::getJiraAcsWorkItemFieldsConfiguration", () => {
+        let user: User;
+
+        afterEach(() => {
+            fetchMock.restore();
+        });
+
+        it("makes a request to the gateway to fetch the ACS field options", () => {
+            user = {
+                authType: GATEWAY_JWT,
+                gatewayUser: { idToken: "some-token", role: UserRole.SUPERADMIN }
+            };
+            fetchMock.get(`${Http.baseUrl()}/integrations/jira/acs/configuration`, 200);
+
+            IntegrationsApi.getJiraAcsWorkItemFieldsConfiguration(user);
+
+            expect(fetchMock.lastCall()[0]).to.eq(`${Http.baseUrl()}/integrations/jira/acs/configuration`);
             expect(fetchMock.lastOptions().headers["Accept"]).to.eq("application/json");
             expect(fetchMock.lastOptions().headers["Authorization"]).to.eq("Bearer some-token");
             expect(fetchMock.lastOptions().method).to.eq("GET");


### PR DESCRIPTION
Two methods on `IntegrationsApi`:

- `createJiraAcsWorkItem` posts to `/integrations/jira/acs/create-work-item`
- `getJiraAcsWorkItemFieldsConfiguration` reads `/integrations/jira/acs/configuration`

Three models. `JiraAcsWorkItemRequestModel` is what a caller passes, `JiraAcsWorkItemRequest` is the wire body, `JiraAcsFieldsConfiguration` is the response. `JiraFieldProperty`, `JiraFieldAssignee`, `ApiResponse` and `ApiResult` are reused unchanged.