### PR TITLE
Add data field to ApiRunningProcess [HMA-350]

### DIFF
--- a/source/models/api/api_running_process.ts
+++ b/source/models/api/api_running_process.ts
@@ -9,13 +9,14 @@ export type ApiRunningProcessArgument = ModifyPartial<ApiRunningProcess, {
 }>
 
 export class ApiRunningProcess {
-  constructor({ id, name, status, startDate, endDate, message }: ApiRunningProcessArgument = {}) {
+  constructor({ id, name, status, startDate, endDate, message, data }: ApiRunningProcessArgument = {}) {
     this.id = id;
     this.name = name;
     this.status = status;
     addInstantGetterAndSetterToApiModel(this, "startDate", startDate);
     addInstantGetterAndSetterToApiModel(this, "endDate", endDate);
     this.message = message;
+    this.data = data;
   }
 
   id: number;
@@ -24,6 +25,13 @@ export class ApiRunningProcess {
   startDate: number;
   endDate: number;
   message: string;
+
+  // Result payload received from the gateway process when we poll it (checkRunningProcess).
+  // For Import Project Data, a FAILED run carries the categorized errors here (an
+  // ApiImportProjectDataErrorResponse) for the frontend to render after polling; null otherwise.
+  // Typed `any` because the gateway column is a general-purpose JSON slot; narrow it with the
+  // isImportProjectDataError type guard before use.
+  data: any;
 }
 
 export default ApiRunningProcess;


### PR DESCRIPTION
## What & why

The gateway now runs Import Project Data validation asynchronously and, on failure, returns the categorized errors on the process's `data` field (polled via `GET /running-processes/{id}`). `ApiRunningProcess` didn't carry `data`, so the payload was dropped before reaching the caller. This adds it.

## Changes

- Added a `data` field (typed `any`, matching the codebase's convention for general-purpose JSON payloads) to `ApiRunningProcess` and its constructor. `ApiRunningProcessArgument` picks it up automatically via `ModifyPartial`.
- Non-breaking / additive. `importProjectData` already returns `Promise<ApiRunningProcess>`, `checkRunningProcess` already exists, and the error types (`ApiImportProjectDataErrorResponse`, `isImportProjectDataError`) already exist — the `data` field was the only missing piece.