### PR TITLE
expose the default priority id on the ACS fields configuration [HMA-1856]

### DIFF
--- a/source/models/api/integrations/jira/JiraAcsFieldsConfiguration.ts
+++ b/source/models/api/integrations/jira/JiraAcsFieldsConfiguration.ts
@@ -7,6 +7,8 @@ export class JiraAcsFieldsConfiguration {
     workItemTypes?: JiraFieldProperty[];
 
     assignees?: JiraFieldAssignee[];
+
+    defaultPriorityId?: number;
 }
 
 export default JiraAcsFieldsConfiguration;


### PR DESCRIPTION
- Adds an optional `defaultPriorityId` to `JiraAcsFieldsConfiguration`

The gateway now reads the priority Jira applies by default off the ACS create screen and returns it on `GET /integrations/jira/acs/configuration`. Exposing it here lets avvir-web pre-select the Priority control by id instead of matching the label "Unprioritized", which would silently leave the control blank if Customer Success renames that priority.

It's a passive optional property on the response DTO — populated straight from the gateway JSON with no client-side transformation — so there's no new logic to unit-test; the existing `getJiraAcsWorkItemFieldsConfiguration` test still covers the endpoint.