### PR TITLE
paginate the PBE list endpoints and drop the removed /optimized method [HMA-1871]

### DIFF
--- a/source/api/element_api.ts
+++ b/source/api/element_api.ts
@@ -8,21 +8,25 @@ import type { User } from "../utilities/get_authorization_headers";
 import {ApiPartialProgressElement} from "../models";
 
 export default class ElementApi {
-  static getPlannedBuildingElements({ projectId, floorId }: AssociationIds, user: User): Promise<ApiPlannedElement[]> {
+  /**
+   * Omit limit to read the whole floor. Passing a limit reads one page instead, so very large floors
+   * don't have to build a single multi-gigabyte response. The page shape is the same either way.
+   */
+  static getPlannedBuildingElements({ projectId, floorId }: AssociationIds, user: User, limit?: number, offset?: number): Promise<ApiPlannedElement[]> {
     let url = `${Http.baseUrl()}/projects/${projectId}/floors/${floorId}/planned-building-elements`;
+    if (limit != null) {
+      url += `?limit=${limit}&offset=${offset ?? 0}`;
+    }
     return Http.get(url, user) as unknown as Promise<ApiDetailedElement[]>;
   }
 
-  static getMinimalPlannedBuildingElements({ projectId, floorId }: AssociationIds, user: User): Promise<ApiMinimalPlannedBuildingElement[]> {
+  /** Pages on the same terms as {@link getPlannedBuildingElements}. */
+  static getMinimalPlannedBuildingElements({ projectId, floorId }: AssociationIds, user: User, limit?: number, offset?: number): Promise<ApiMinimalPlannedBuildingElement[]> {
     let url = `${Http.baseUrl()}/projects/${projectId}/floors/${floorId}/planned-building-elements/minimal`;
+    if (limit != null) {
+      url += `?limit=${limit}&offset=${offset ?? 0}`;
+    }
     return Http.get(url, user) as unknown as Promise<ApiMinimalPlannedBuildingElement[]>;
-  }
-
-  // same shape as getPlannedBuildingElements, but deviation vectors are trimmed to
-  // INCLUDED-only server-side. getPlannedBuildingElements remains the fallback.
-  static getOptimizedPlannedBuildingElements({ projectId, floorId }: AssociationIds, user: User): Promise<ApiPlannedElement[]> {
-    let url = `${Http.baseUrl()}/projects/${projectId}/floors/${floorId}/planned-building-elements/optimized`;
-    return Http.get(url, user) as unknown as Promise<ApiPlannedElement[]>;
   }
 
   static updateDeviationStatus({ projectId, floorId, scanDatasetId }: AssociationIds,

--- a/source/models/api/api_minimal_planned_building_element.ts
+++ b/source/models/api/api_minimal_planned_building_element.ts
@@ -5,4 +5,5 @@ export interface ApiMinimalPlannedBuildingElement {
   builtStatus: ApiBuiltStatus;
   trade?: string;
   uniformat?: string;
+  excludeFromAnalysis?: boolean;
 }

--- a/tests/api/element_api_test.ts
+++ b/tests/api/element_api_test.ts
@@ -7,7 +7,7 @@ import { DETECTED, DeviationStatus, INCLUDED } from "../../source/models/enums/d
 import { ApiBuiltStatus, DEVIATED, NOT_BUILT } from "../../source/models/enums/api_built_status";
 import { FIREBASE, GATEWAY_JWT, UserAuthType } from "../../source/models/enums/user_auth_type";
 import { USER, UserRole } from "../../source/models/enums/user_role";
-import { ApiDetailedElement, ApiPlannedElement, ApiScannedElement, DateConverter } from "../../source";
+import { ApiDetailedElement, ApiMinimalPlannedBuildingElement, ApiPlannedElement, ApiScannedElement, DateConverter } from "../../source";
 import { describe } from "mocha";
 
 describe("ElementApi", () => {
@@ -104,17 +104,77 @@ describe("ElementApi", () => {
         expect(lastFetchOpts.headers.Authorization).to.eq("Bearer some-firebase.id.token");
       });
     });
+
+    describe("when a limit and an offset are given", () => {
+      beforeEach(() => {
+        fetchMock.get(`${Http.baseUrl()}/projects/some-project-id/floors/some-floor-id/planned-building-elements?limit=100&offset=200`, []);
+      });
+
+      it("requests that page", () => {
+        ElementApi.getPlannedBuildingElements({
+          projectId: "some-project-id",
+          floorId: "some-floor-id"
+        }, {
+          authType: GATEWAY_JWT,
+          gatewayUser: { idToken: "some-firebase.id.token", role: USER }
+        }, 100, 200);
+
+        expect(fetchMock.lastCall()[0])
+          .to
+          .eq(`${Http.baseUrl()}/projects/some-project-id/floors/some-floor-id/planned-building-elements?limit=100&offset=200`);
+      });
+    });
+
+    describe("when only a limit is given", () => {
+      beforeEach(() => {
+        fetchMock.get(`${Http.baseUrl()}/projects/some-project-id/floors/some-floor-id/planned-building-elements?limit=100&offset=0`, []);
+      });
+
+      it("defaults the offset to 0", () => {
+        ElementApi.getPlannedBuildingElements({
+          projectId: "some-project-id",
+          floorId: "some-floor-id"
+        }, {
+          authType: GATEWAY_JWT,
+          gatewayUser: { idToken: "some-firebase.id.token", role: USER }
+        }, 100);
+
+        expect(fetchMock.lastCall()[0])
+          .to
+          .eq(`${Http.baseUrl()}/projects/some-project-id/floors/some-floor-id/planned-building-elements?limit=100&offset=0`);
+      });
+    });
+
+    describe("when only an offset is given", () => {
+      it("sends no pagination params — the gateway ignores an offset without a limit", () => {
+        ElementApi.getPlannedBuildingElements({
+          projectId: "some-project-id",
+          floorId: "some-floor-id"
+        }, {
+          authType: GATEWAY_JWT,
+          gatewayUser: { idToken: "some-firebase.id.token", role: USER }
+        }, undefined, 200);
+
+        expect(fetchMock.lastCall()[0])
+          .to
+          .eq(`${Http.baseUrl()}/projects/some-project-id/floors/some-floor-id/planned-building-elements`);
+      });
+    });
   });
 
   describe("::getMinimalPlannedBuildingElements", () => {
+    // typed so that dropping a field from ApiMinimalPlannedBuildingElement fails the build here
+    const minimalPayload: ApiMinimalPlannedBuildingElement[] = [{
+      globalId: "some-element-id",
+      builtStatus: ApiBuiltStatus.DEVIATED,
+      trade: "some-trade",
+      uniformat: "A1010.10",
+      excludeFromAnalysis: true
+    }];
+
     beforeEach(() => {
       fetchMock.get(`${Http.baseUrl()}/projects/some-project-id/floors/some-floor-id/planned-building-elements/minimal`,
-        [{
-          globalId: "some-element-id",
-          builtStatus: ApiBuiltStatus.DEVIATED,
-          trade: "some-trade",
-          uniformat: "A1010.10"
-        }]);
+        minimalPayload);
     });
 
     it("makes a request to the minimal planned building elements endpoint", () => {
@@ -146,7 +206,8 @@ describe("ElementApi", () => {
             globalId: "some-element-id",
             builtStatus: DEVIATED,
             trade: "some-trade",
-            uniformat: "A1010.10"
+            uniformat: "A1010.10",
+            excludeFromAnalysis: true
           }]);
         });
     });
@@ -170,90 +231,63 @@ describe("ElementApi", () => {
         expect(lastFetchOpts.headers.Authorization).to.eq("Bearer some-firebase.id.token");
       });
     });
-  });
 
-  describe("::getOptimizedPlannedBuildingElements", () => {
-    beforeEach(() => {
-      fetchMock.get(`${Http.baseUrl()}/projects/some-project-id/floors/some-floor-id/planned-building-elements/optimized`,
-        [{
-          name: "Some Element Name",
-          globalId: "some-element-id",
-          uniformat: "A1010.10",
-          trade: "some-trade",
-          deviation: {
-            deviationMeters: 1.4142135623730951,
-            status: DeviationStatus.INCLUDED,
-            deviationVectorMeters: {
-              x: 1,
-              y: 1,
-              z: 0
-            }
-          }
-        }]);
-    });
-
-    it("makes a request to the optimized planned building elements endpoint", () => {
-      ElementApi.getOptimizedPlannedBuildingElements({
-        projectId: "some-project-id",
-        floorId: "some-floor-id"
-      }, {
-        authType: GATEWAY_JWT,
-        gatewayUser: { idToken: "some-firebase.id.token", role: USER }
+    describe("when a limit and an offset are given", () => {
+      beforeEach(() => {
+        fetchMock.get(`${Http.baseUrl()}/projects/some-project-id/floors/some-floor-id/planned-building-elements/minimal?limit=100&offset=200`, []);
       });
 
-      const fetchCall = fetchMock.lastCall();
-      expect(fetchCall[0])
-        .to
-        .eq(`${Http.baseUrl()}/projects/some-project-id/floors/some-floor-id/planned-building-elements/optimized`);
-      expect(fetchMock.lastOptions().headers.Accept).to.eq("application/json");
-    });
-
-    it("returns the optimized element payload", () => {
-      return ElementApi.getOptimizedPlannedBuildingElements({
+      it("requests that page", () => {
+        ElementApi.getMinimalPlannedBuildingElements({
           projectId: "some-project-id",
           floorId: "some-floor-id"
         }, {
           authType: GATEWAY_JWT,
           gatewayUser: { idToken: "some-firebase.id.token", role: USER }
-        })
-        .then((optimizedElements) => {
-          expect(optimizedElements).to.deep.eq([{
-            name: "Some Element Name",
-            globalId: "some-element-id",
-            uniformat: "A1010.10",
-            trade: "some-trade",
-            deviation: {
-              deviationMeters: Math.sqrt(2),
-              status: INCLUDED,
-              deviationVectorMeters: {
-                x: 1,
-                y: 1,
-                z: 0
-              }
-            }
-          }]);
-        });
+        }, 100, 200);
+
+        expect(fetchMock.lastCall()[0])
+          .to
+          .eq(`${Http.baseUrl()}/projects/some-project-id/floors/some-floor-id/planned-building-elements/minimal?limit=100&offset=200`);
+      });
     });
 
-    describe("when the user is signed in", () => {
-      let user;
+    describe("when only a limit is given", () => {
       beforeEach(() => {
-        user = {
-          authType: GATEWAY_JWT,
-          gatewayUser: { idToken: "some-firebase.id.token", role: USER }
-        };
+        fetchMock.get(`${Http.baseUrl()}/projects/some-project-id/floors/some-floor-id/planned-building-elements/minimal?limit=100&offset=0`, []);
       });
 
-      it("authenticates the request", () => {
-        ElementApi.getOptimizedPlannedBuildingElements({
+      it("defaults the offset to 0", () => {
+        ElementApi.getMinimalPlannedBuildingElements({
           projectId: "some-project-id",
           floorId: "some-floor-id"
-        }, user);
+        }, {
+          authType: GATEWAY_JWT,
+          gatewayUser: { idToken: "some-firebase.id.token", role: USER }
+        }, 100);
 
-        const lastFetchOpts = fetchMock.lastOptions();
-        expect(lastFetchOpts.headers.Authorization).to.eq("Bearer some-firebase.id.token");
+        expect(fetchMock.lastCall()[0])
+          .to
+          .eq(`${Http.baseUrl()}/projects/some-project-id/floors/some-floor-id/planned-building-elements/minimal?limit=100&offset=0`);
       });
     });
+
+    describe("when only an offset is given", () => {
+      it("sends no pagination params — the gateway ignores an offset without a limit", () => {
+        ElementApi.getMinimalPlannedBuildingElements({
+          projectId: "some-project-id",
+          floorId: "some-floor-id"
+        }, {
+          authType: GATEWAY_JWT,
+          gatewayUser: { idToken: "some-firebase.id.token", role: USER }
+        }, undefined, 200);
+
+        expect(fetchMock.lastCall()[0])
+          .to
+          .eq(`${Http.baseUrl()}/projects/some-project-id/floors/some-floor-id/planned-building-elements/minimal`);
+      });
+    });
+
   });
 
   describe("::updateDeviationStatus", () => {


### PR DESCRIPTION
  - `getPlannedBuildingElements` and `getMinimalPlannedBuildingElements` take optional                                                               
    `limit` / `offset`                                                                                                                               
  - `ApiMinimalPlannedBuildingElement` gains `excludeFromAnalysis`, which `/minimal` now emits                                                       
  - **Removed** `getOptimizedPlannedBuildingElements` — the `/optimized` endpoint no longer                                                          
    exists on the gateway   