### PR TITLE
persist This Scan / All to Date in view ViewFilters [HMA-1976]

### DIFF
--- a/source/models/api/api_view.ts
+++ b/source/models/api/api_view.ts
@@ -70,11 +70,12 @@ export type ViewFiltersArgument = ModifyPartial<ViewFilters, {
 export class ViewFilters {
   constructor(filters: ViewFiltersArgument = {}) {
     if (filters) {
-      const { trades, deviationTolerance, pointCloudVisible, sectionPointCloud } = filters;
+      const { trades, deviationTolerance, pointCloudVisible, sectionPointCloud, onlyShowDeviationsFromCurrentScan } = filters;
       this.trades = new ViewTrades(trades);
       this.deviationTolerance = new DeviationTolerance(deviationTolerance);
       this.pointCloudVisible = pointCloudVisible;
       this.sectionPointCloud = sectionPointCloud;
+      this.onlyShowDeviationsFromCurrentScan = onlyShowDeviationsFromCurrentScan;
     } else {
       this.trades = new ViewTrades();
       this.deviationTolerance = new DeviationTolerance();
@@ -85,6 +86,7 @@ export class ViewFilters {
   deviationTolerance: DeviationTolerance;
   pointCloudVisible: boolean;
   sectionPointCloud: boolean;
+  onlyShowDeviationsFromCurrentScan: boolean;
 }
 
 export type SelectedElements = string[]


### PR DESCRIPTION
## Persist This Scan / All to Date in view ViewFilters

Adds `onlyShowDeviationsFromCurrentScan` to `ApiView.ViewFilters`.

The client's `ViewFilters` only carried `trades / deviationTolerance / pointCloudVisible / sectionPointCloud`, so the scan-comparison mode was silently stripped before a shared view was POSTed. This lets it be saved to and restored from viewpoints.