### PR TITLE
Expose built element counts per floor [HMA-1937]

### DIFF
--- a/source/api/project_api.ts
+++ b/source/api/project_api.ts
@@ -47,6 +47,11 @@ export default class ProjectApi {
     return Http.get(url, user) as unknown as Promise<{[floorFirebaseId: string]: {[tradeCode: string]: number}}>;
   }
 
+  static getProjectFloorBuiltElementCounts({ projectId }: AssociationIds, user: User): Promise<{[floorFirebaseId: string]: number}> {
+    let url = `${Http.baseUrl()}/projects/${projectId}/built-elements-by-floor`;
+    return Http.get(url, user) as unknown as Promise<{[floorFirebaseId: string]: number}>;
+  }
+
   static getProjectDeviationSummary({ projectId }: AssociationIds, user: User): Promise<ApiProjectDeviationSummary> {
     let url = `${Http.baseUrl()}/projects/${projectId}/deviation-summary`;
     return Http.get(url, user) as unknown as Promise<ApiProjectDeviationSummary>;

--- a/tests/api/project_api_test.ts
+++ b/tests/api/project_api_test.ts
@@ -250,6 +250,46 @@ describe("ProjectApi", () => {
     });
   });
 
+  describe("#getProjectFloorBuiltElementCounts", () => {
+    beforeEach(() => {
+      fetchMock.get(`${Http.baseUrl()}/projects/some-project-id/built-elements-by-floor`, {
+        status: 200,
+        body: {
+          "some-floor-id": 12,
+        }
+      });
+    });
+
+    it("makes a request to the gateway api", () => {
+      ProjectApi.getProjectFloorBuiltElementCounts({ projectId: "some-project-id" }, {
+        authType: "GATEWAY_JWT",
+        gatewayUser: { idToken: "some-firebase.id.token" }
+      });
+      const fetchCall = fetchMock.lastCall();
+
+      expect(fetchCall[0]).to.eq(`${Http.baseUrl()}/projects/some-project-id/built-elements-by-floor`);
+      expect(fetchMock.lastOptions().headers.Accept).to.eq("application/json");
+    });
+
+    it("includes the authorization headers", () => {
+      ProjectApi.getProjectFloorBuiltElementCounts({ projectId: "some-project-id" }, {
+        authType: "GATEWAY_JWT",
+        gatewayUser: { idToken: "some-firebase.id.token" }
+      });
+
+      expect(fetchMock.lastOptions().headers.Authorization).to.eq("Bearer some-firebase.id.token");
+    });
+
+    it("returns the built element counts keyed by floor firebase id", () => {
+      return ProjectApi.getProjectFloorBuiltElementCounts({ projectId: "some-project-id" }, {
+        authType: "GATEWAY_JWT",
+        gatewayUser: { idToken: "some-firebase.id.token" }
+      }).then((builtCounts) => {
+        expect(builtCounts).to.deep.eq({ "some-floor-id": 12 });
+      });
+    });
+  });
+
   describe("#getProjectDeviationSummary", () => {
     beforeEach(() => {
       fetchMock.get(`${Http.baseUrl()}/projects/some-project-id/deviation-summary`, {


### PR DESCRIPTION
Adds `Avvir.api.projects.getProjectFloorBuiltElementCounts({ projectId }, user)` for the gateway's new `GET /projects/{projectId}/built-elements-by-floor`, returning `{ [floorFirebaseId]: number }`.

The as-built IFC export wizard ([HMA-1937](https://multivista.atlassian.net/browse/HMA-1937)) uses it to tag areas an export would produce nothing for. The deviation magnitudes it already fetches cannot answer that on their own: an element built at its designed position reports a magnitude of zero, exactly like an element that was never built.

## Tests

3 new cases in `tests/api/project_api_test.ts` (URL, auth headers, response shape). 61 passing locally for that file.

## Release

`Avvir/avvir-web`'s HMA-1937 branch needs this published; it is pinned at `avvir@^8.9.2` and will not compile until then.

## Related

- `Avvir/avvir-web-gateway#1460` — the endpoint
- `Avvir/avvir-web` — the wizard that consumes it

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[HMA-1937]: https://multivista.atlassian.net/browse/HMA-1937?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ