### PR TITLE
Expose built element counts per floor and trade [HMA-1938]

### DIFF
--- a/source/api/project_api.ts
+++ b/source/api/project_api.ts
@@ -52,6 +52,11 @@ export default class ProjectApi {
     return Http.get(url, user) as unknown as Promise<{[floorFirebaseId: string]: number}>;
   }
 
+  static getProjectFloorTradeBuiltElementCounts({ projectId }: AssociationIds, user: User): Promise<{[floorFirebaseId: string]: {[tradeCode: string]: number}}> {
+    let url = `${Http.baseUrl()}/projects/${projectId}/built-elements-by-floor-and-trade`;
+    return Http.get(url, user) as unknown as Promise<{[floorFirebaseId: string]: {[tradeCode: string]: number}}>;
+  }
+
   static getProjectDeviationSummary({ projectId }: AssociationIds, user: User): Promise<ApiProjectDeviationSummary> {
     let url = `${Http.baseUrl()}/projects/${projectId}/deviation-summary`;
     return Http.get(url, user) as unknown as Promise<ApiProjectDeviationSummary>;

--- a/tests/api/project_api_test.ts
+++ b/tests/api/project_api_test.ts
@@ -290,6 +290,46 @@ describe("ProjectApi", () => {
     });
   });
 
+  describe("#getProjectFloorTradeBuiltElementCounts", () => {
+    beforeEach(() => {
+      fetchMock.get(`${Http.baseUrl()}/projects/some-project-id/built-elements-by-floor-and-trade`, {
+        status: 200,
+        body: {
+          "some-floor-id": { "03": 12, "06": 3 },
+        }
+      });
+    });
+
+    it("makes a request to the gateway api", () => {
+      ProjectApi.getProjectFloorTradeBuiltElementCounts({ projectId: "some-project-id" }, {
+        authType: "GATEWAY_JWT",
+        gatewayUser: { idToken: "some-firebase.id.token" }
+      });
+      const fetchCall = fetchMock.lastCall();
+
+      expect(fetchCall[0]).to.eq(`${Http.baseUrl()}/projects/some-project-id/built-elements-by-floor-and-trade`);
+      expect(fetchMock.lastOptions().headers.Accept).to.eq("application/json");
+    });
+
+    it("includes the authorization headers", () => {
+      ProjectApi.getProjectFloorTradeBuiltElementCounts({ projectId: "some-project-id" }, {
+        authType: "GATEWAY_JWT",
+        gatewayUser: { idToken: "some-firebase.id.token" }
+      });
+
+      expect(fetchMock.lastOptions().headers.Authorization).to.eq("Bearer some-firebase.id.token");
+    });
+
+    it("returns the built element counts keyed by floor firebase id and then trade code", () => {
+      return ProjectApi.getProjectFloorTradeBuiltElementCounts({ projectId: "some-project-id" }, {
+        authType: "GATEWAY_JWT",
+        gatewayUser: { idToken: "some-firebase.id.token" }
+      }).then((builtCounts) => {
+        expect(builtCounts).to.deep.eq({ "some-floor-id": { "03": 12, "06": 3 } });
+      });
+    });
+  });
+
   describe("#getProjectDeviationSummary", () => {
     beforeEach(() => {
       fetchMock.get(`${Http.baseUrl()}/projects/some-project-id/deviation-summary`, {


### PR DESCRIPTION
Adds `Avvir.api.projects.getProjectFloorTradeBuiltElementCounts({ projectId }, user)` for the gateway's new `GET /projects/{projectId}/built-elements-by-floor-and-trade`, returning `{ [floorFirebaseId]: { [tradeCode]: number } }`.

The as-built IFC export's trade step ([HMA-1938](https://multivista.atlassian.net/browse/HMA-1938)) uses it to disable a trade with nothing built in the selected areas. The deviation magnitudes it already fetches cannot answer that: a trade built at its designed position reports a magnitude of zero, exactly like a trade that was never built.

## Tests

3 new cases in `tests/api/project_api_test.ts` (URL, auth headers, response shape). 64 passing locally for that file.

## Release

`Avvir/avvir-web`'s HMA-1938 branch needs this published as `avvir@8.9.3`; it is pinned at `avvir@^8.9.3` and will not compile until then.

## Related

- `Avvir/avvir-web-gateway#1465` — the endpoint
- `Avvir/avvir-web` — the trade step that consumes it

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[HMA-1938]: https://multivista.atlassian.net/browse/HMA-1938?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ